### PR TITLE
don't forget which message was selected

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -76,7 +76,6 @@ function mail.show_about(name)
 end
 
 function mail.show_inbox(name)
-	selected_idxs.messages[name] = nil
 	local formspec = { mail.inbox_formspec }
 	local messages = mail.getMessages(name)
 


### PR DESCRIPTION
currently, if you delete a message, we forget which message index was selected, so you have to click on another message to delete/read another. previously, you could keep hitting "delete" to remove many messages. this was something i introduced w/ the last PR, i don't remember why or even if it was intentional. 