### PR TITLE
Show date time

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -273,7 +273,8 @@ function mail.show_message(name, msgnumber)
 	local from = minetest.formspec_escape(message.sender) or ""
 	local to = minetest.formspec_escape(message.to) or ""
 	local cc = minetest.formspec_escape(message.cc) or ""
-	local date = minetest.formspec_escape(os.date("%Y-%m-%d %X", message.time)) or ""
+	local date = type(message.time) == "number"
+		and minetest.formspec_escape(os.date("%Y-%m-%d %X", message.time)) or ""
 	local subject = minetest.formspec_escape(message.subject) or ""
 	local body = minetest.formspec_escape(message.body) or ""
 	formspec = string.format(formspec, from, to, cc, date, subject, body)

--- a/gui.lua
+++ b/gui.lua
@@ -257,13 +257,19 @@ function mail.show_message(name, msgnumber)
 	local message = messages[msgnumber]
 	local formspec = [[
 			size[8,9]
-			button[7.25,0;0.75,0.5;back;X]
-			label[0,0;From: %s]
-			label[0,0.4;To: %s]
-			label[0,0.8;CC: %s]
-			label[4,0;Date: %s]
-			label[0,1.3;Subject: %s]
-			textarea[0.25,1.8;8,7.8;;;%s]
+
+			box[0,0;7,1.9;#466432]
+
+			button[7.25,0.15;0.75,0.5;back;X]
+
+			label[0.2,0.1;From: %s]
+			label[0.2,0.5;To: %s]
+			label[0.2,0.9;CC: %s]
+			label[0.2,1.3;Date: %s]
+
+			label[0,2.1;Subject: %s]
+			textarea[0.25,2.6;8,7.0;;;%s]
+
 			button[0,8.5;2,1;reply;Reply]
 			button[2,8.5;2,1;replyall;Reply All]
 			button[4,8.5;2,1;forward;Forward]

--- a/gui.lua
+++ b/gui.lua
@@ -261,6 +261,7 @@ function mail.show_message(name, msgnumber)
 			label[0,0;From: %s]
 			label[0,0.4;To: %s]
 			label[0,0.8;CC: %s]
+			label[4,0;Date: %s]
 			label[0,1.3;Subject: %s]
 			textarea[0.25,1.8;8,7.8;;;%s]
 			button[0,8.5;2,1;reply;Reply]
@@ -272,9 +273,10 @@ function mail.show_message(name, msgnumber)
 	local from = minetest.formspec_escape(message.sender) or ""
 	local to = minetest.formspec_escape(message.to) or ""
 	local cc = minetest.formspec_escape(message.cc) or ""
+	local date = minetest.formspec_escape(os.date("%Y-%m-%d %X", message.time)) or ""
 	local subject = minetest.formspec_escape(message.subject) or ""
 	local body = minetest.formspec_escape(message.body) or ""
-	formspec = string.format(formspec, from, to, cc, subject, body)
+	formspec = string.format(formspec, from, to, cc, date, subject, body)
 
 	if message.unread then
 		message.unread = false


### PR DESCRIPTION
This merge request allows you to see the date and the time while reading the message. It is based on `os.date()` native function which convert the epoch stored in the `.json` into a specific string, here `%Y-%m-%d %X`.

Related to #19 
![screenshot_20230223_124449](https://user-images.githubusercontent.com/75171564/220898484-657082a6-15e5-42c8-b516-94207c5abb9c.png)
