### PR TITLE
use canonical_name if it is available; report error when recipients don't exist

### DIFF
--- a/api.md
+++ b/api.md
@@ -35,12 +35,13 @@ mail = {
 ## Sending mail
 Old variant (pre-1.1)
 ```lua
-mail.send("source name", "destination name", "subject line", "mail body")
+local error = mail.send("source name", "destination name", "subject line", "mail body")
+-- error will contain an error message if mail couldn't be delivered, otherwise nil
 ```
 
 New variant (1.1+)
 ```lua
-mail.send({
+local error = mail.send({
 	from = "sender name",
 	to = "destination name",
 	cc = "carbon copy",
@@ -48,6 +49,7 @@ mail.send({
 	subject = "subject line",
 	body = "mail body"
 })
+-- error will contain an error message if mail couldn't be delivered, otherwise nil
 ```
 
 # Hooks

--- a/gui.lua
+++ b/gui.lua
@@ -464,7 +464,7 @@ function mail.handle_receivefields(player, formname, fields)
 	elseif formname == "mail:compose" then
 		local name = player:get_player_name()
 		if fields.send then
-			mail.send({
+			local error = mail.send({
 				from = name,
 				to = fields.to,
 				cc = fields.cc,
@@ -472,6 +472,11 @@ function mail.handle_receivefields(player, formname, fields)
 				subject = fields.subject,
 				body = fields.body,
 			})
+			if error then
+				minetest.chat_send_player(name, error)
+				return
+			end
+
 			local contacts = mail.getContacts(name)
 			local recipients = mail.parse_player_list(fields.to)
 			local changed = false

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = mail
 description = ingame mail-system
-optional_depends = unified_inventory,default,mtt
+optional_depends = canonical_name,default,mtt,unified_inventory

--- a/mtt.lua
+++ b/mtt.lua
@@ -1,11 +1,11 @@
 
 mtt.register("send mail", function(callback)
     local auth_handler = minetest.get_auth_handler()
-    if not auth_handler:get_auth("player1") then
-        auth_handler:create_auth("player1", "test")
+    if not auth_handler.get_auth("player1") then
+        auth_handler.create_auth("player1", "test")
     end
-    if not auth_handler:get_auth("player2") then
-        auth_handler:create_auth("player2", "test")
+    if not auth_handler.get_auth("player2") then
+        auth_handler.create_auth("player2", "test")
     end
 
     -- send a mail

--- a/mtt.lua
+++ b/mtt.lua
@@ -1,5 +1,13 @@
 
 mtt.register("send mail", function(callback)
+    local auth_handler = minetest.get_auth_handler()
+    if not auth_handler:get_auth("player1") then
+        auth_handler:create_auth("player1", "test")
+    end
+    if not auth_handler:get_auth("player2") then
+        auth_handler:create_auth("player2", "test")
+    end
+
     -- send a mail
     mail.send("player1", "player2", "something", "blah")
 


### PR DESCRIPTION
the main aim of this PR was to make use of my [canonical_name](https://content.minetest.net/packages/rheo/canonical_name/) mod if possible. canonical_name corrects mis-capitalized user names. if canonical_name is installed, sending mail to "FlUX" will correctly be delivered to "flux", instead of ending up in limbo. 

i also added a basic feature where a sender is alerted w/ a chat message if one or more of the recipients does not exist. 