### PR TITLE
Repair forward button in read view

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -458,7 +458,7 @@ function mail.handle_receivefields(player, formname, fields)
 
 		elseif fields.forward then
 			local message = messages[selected_idxs.messages[name]]
-			mail.forward(name, message.subject)
+			mail.forward(name, message)
 
 		elseif fields.delete then
 			if messages[selected_idxs.messages[name]] then


### PR DESCRIPTION
It was due to an extra statement (`message.subject`). It now works whatever you're in inbox or in message reading formspec.

Related to #13  

Tested with 5.4.1