### PR TITLE
declare the translator in every module instead of a global

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,3 @@
-allow_defined_top = true
-
 globals = {
 	"mail",
 }

--- a/init.lua
+++ b/init.lua
@@ -31,9 +31,6 @@ if minetest.get_modpath("default") then
 	mail.theme = default.gui_bg .. default.gui_bg_img
 end
 
--- translation
-S = minetest.get_translator("mail")
-
 -- sub files
 local MP = minetest.get_modpath(minetest.get_current_modname())
 dofile(MP .. "/util/normalize.lua")

--- a/ui/compose.lua
+++ b/ui/compose.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:compose"
 local msg_id = nil
 

--- a/ui/contacts.lua
+++ b/ui/contacts.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:contacts"
 
 local contacts_formspec = "size[8,9;]" .. mail.theme .. [[

--- a/ui/drafts.lua
+++ b/ui/drafts.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local drafts_formspec = "size[8.5,10;]" .. mail.theme .. [[
     tabheader[0.3,1;boxtab;]] .. S("Inbox") .. "," .. S("Sent messages").. "," .. S("Drafts") .. [[;3;false;false]
 

--- a/ui/edit_contact.lua
+++ b/ui/edit_contact.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:editcontact"
 
 function mail.show_edit_contact(name, contact_name, note, illegal_name_hint)

--- a/ui/edit_maillists.lua
+++ b/ui/edit_maillists.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:editmaillist"
 
 function mail.show_edit_maillist(playername, maillist_name, desc, players, illegal_name_hint)

--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local inbox_formspec = "size[8.5,10;]" .. mail.theme .. [[
     tabheader[0.3,1;boxtab;]] .. S("Inbox") .. "," .. S("Sent messages").. "," .. S("Drafts") .. [[;1;false;false]
 

--- a/ui/maillists.lua
+++ b/ui/maillists.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:maillists"
 
 local maillists_formspec = "size[8,9;]" .. mail.theme .. [[

--- a/ui/message.lua
+++ b/ui/message.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:message"
 
 function mail.show_message(name, id)

--- a/ui/outbox.lua
+++ b/ui/outbox.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local sent_formspec = "size[8.5,10;]" .. mail.theme .. [[
     tabheader[0.3,1;boxtab;]] .. S("Inbox") .. "," .. S("Sent messages").. "," .. S("Drafts") .. [[;2;false;false]
 

--- a/ui/select_contact.lua
+++ b/ui/select_contact.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 local FORMNAME = "mail:selectcontact"
 
 local select_contact_formspec = "size[8,9;]" .. mail.theme .. [[


### PR DESCRIPTION
@Athozus i took the liberty and moved the translator var into the dependent modules
The `S` variable would leak into the global namespace otherwise (other mods can't really use this anyway)