### PR TITLE
Fix oversized selected number

### DIFF
--- a/ui/events.lua
+++ b/ui/events.lua
@@ -248,7 +248,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
             if #mail.selected_idxs.sent[name] >= #getOutbox() then -- if selection is full
                 mail.selected_idxs.sent[name] = {}
             else
-                mail.selected_idxs.inbox[name] = {} -- reset to avoid duplicates
+                mail.selected_idxs.sent[name] = {} -- reset to avoid duplicates
                 mail.selected_idxs.multipleselection[name] = true
                 for _, msg in ipairs(getOutbox()) do
                     table.insert(mail.selected_idxs.sent[name], msg.id)


### PR DESCRIPTION
If you had some items selected in `outbox` and then you clicked on selected all, you got an oversized number (ex 235 instead of 122 messages), because of an `inbox` instead of `sent` in the `selected_idxs`.

This is a trivial issue, so I merge directly.