### PR TITLE
Fix lag with multiple selection action

### DIFF
--- a/storage.lua
+++ b/storage.lua
@@ -73,54 +73,69 @@ function mail.sort_messages(messages, sortfield, descending, filter)
 end
 
 -- marks a mail read by its id
-function mail.mark_read(playername, msg_id)
+function mail.mark_read(playername, msg_ids)
 	local entry = mail.get_storage_entry(playername)
-	for _, msg in ipairs(entry.inbox) do
-		if msg.id == msg_id then
-			msg.read = true
-			mail.set_storage_entry(playername, entry)
-			mail.hud_update(playername, entry.inbox)
-			return
+	if type(msg_ids) ~= "table" then -- if this is not a table
+		msg_ids = { msg_ids }
+	end
+	for _, read_msg_id in ipairs(msg_ids) do
+		for _, entry_msg in ipairs(entry.inbox) do
+			if entry_msg.id == read_msg_id then
+				entry_msg.read = true
+			end
 		end
 	end
+	mail.set_storage_entry(playername, entry)
+	mail.hud_update(playername, entry.inbox)
+	return
 end
 
 -- marks a mail unread by its id
-function mail.mark_unread(playername, msg_id)
+function mail.mark_unread(playername, msg_ids)
 	local entry = mail.get_storage_entry(playername)
-	for _, msg in ipairs(entry.inbox) do
-		if msg.id == msg_id then
-			msg.read = false
-			mail.set_storage_entry(playername, entry)
-			return
+	if type(msg_ids) ~= "table" then -- if this is not a table
+		msg_ids = { msg_ids }
+	end
+	for _, unread_msg_id in ipairs(msg_ids) do
+		for _, entry_msg in ipairs(entry.inbox) do
+			if entry_msg.id == unread_msg_id then
+				entry_msg.read = false
+			end
 		end
 	end
+	mail.set_storage_entry(playername, entry)
+	return
 end
 
 -- deletes a mail by its id
-function mail.delete_mail(playername, msg_id)
+function mail.delete_mail(playername, msg_ids)
 	local entry = mail.get_storage_entry(playername)
+	if type(msg_ids) ~= "table" then -- if this is not a table
+		msg_ids = { msg_ids }
+	end
 	for i, msg in ipairs(entry.inbox) do
-		if msg.id == msg_id then
-			table.remove(entry.inbox, i)
-			mail.set_storage_entry(playername, entry)
-			return
+		for _, deleted_msg in ipairs(msg_ids) do
+			if msg.id == deleted_msg then
+				table.remove(entry.inbox, i)
+			end
 		end
 	end
 	for i, msg in ipairs(entry.outbox) do
-		if msg.id == msg_id then
-			table.remove(entry.outbox, i)
-			mail.set_storage_entry(playername, entry)
-			return
+		for _, deleted_msg in ipairs(msg_ids) do
+			if msg.id == deleted_msg then
+				table.remove(entry.outbox, i)
+			end
 		end
 	end
 	for i, msg in ipairs(entry.drafts) do
-		if msg.id == msg_id then
-			table.remove(entry.drafts, i)
-			mail.set_storage_entry(playername, entry)
-			return
+		for _, deleted_msg in ipairs(msg_ids) do
+			if msg.id == deleted_msg then
+				table.remove(entry.drafts, i)
+			end
 		end
 	end
+	mail.set_storage_entry(playername, entry)
+	return
 end
 
 -- add or update a contact

--- a/ui/events.lua
+++ b/ui/events.lua
@@ -157,13 +157,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
     elseif fields.delete then
         if formname == "mail:inbox" and mail.selected_idxs.inbox[name] then -- inbox table
-            for _, msg_id in ipairs(mail.selected_idxs.inbox[name]) do
-                mail.delete_mail(name, msg_id)
-            end
+            mail.delete_mail(name, mail.selected_idxs.inbox[name])
         elseif formname == "mail:sent" and mail.selected_idxs.sent[name] then -- sent table
-            for _, msg_id in ipairs(mail.selected_idxs.sent[name]) do
-                mail.delete_mail(name, msg_id)
-            end
+            mail.delete_mail(name, mail.selected_idxs.sent[name])
         elseif formname == "mail:drafts" and messagesDrafts[mail.selected_idxs.drafts[name]] then -- drafts table
             mail.delete_mail(name, messagesDrafts[mail.selected_idxs.drafts[name]].id)
         end
@@ -199,18 +195,14 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
     elseif fields.markread then
         if formname == "mail:inbox" and mail.selected_idxs.inbox[name] then
-            for _, msg_id in ipairs(mail.selected_idxs.inbox[name]) do
-                mail.mark_read(name, msg_id)
-            end
+            mail.mark_read(name, mail.selected_idxs.inbox[name])
         end
 
         mail.show_mail_menu(name, sortfieldindex, sortdirection, filter)
 
     elseif fields.markunread then
         if formname == "mail:inbox" and mail.selected_idxs.inbox[name] then
-            for _, msg_id in ipairs(mail.selected_idxs.inbox[name]) do
-                mail.mark_unread(name, msg_id)
-            end
+            mail.mark_unread(name, mail.selected_idxs.inbox[name])
         end
 
         mail.show_mail_menu(name, sortfieldindex, sortdirection, filter)


### PR DESCRIPTION
Reduce significantly time of action on several messages

It calls only one time for each action (eg. mark read) the entry, instead of one for each messages. So, it passes from 200 calls to only 1. For ex, it reduces execution time from 20 seconds to less than 0.5.