### PR TITLE
fix `mail.delete_mail` (again)

### DIFF
--- a/storage.lua
+++ b/storage.lua
@@ -114,30 +114,27 @@ function mail.delete_mail(playername, msg_ids)
 	if type(msg_ids) ~= "table" then -- if this is not a table
 		msg_ids = { msg_ids }
 	end
-	if #entry.inbox > 0 then
-		for i = #entry.inbox, 1, -1 do
-			for _, deleted_msg in ipairs(msg_ids) do
-				if entry.inbox[i].id == deleted_msg then
-					table.remove(entry.inbox, i)
-				end
+	for i = #entry.inbox, 1, -1 do
+		for _, deleted_msg in ipairs(msg_ids) do
+			if entry.inbox[i].id == deleted_msg then
+				table.remove(entry.inbox, i)
+				break
 			end
 		end
 	end
-	if #entry.outbox > 0 then
-		for i = #entry.outbox, 1, -1 do
-			for _, deleted_msg in ipairs(msg_ids) do
-				if entry.outbox[i].id == deleted_msg then
-					table.remove(entry.outbox, i)
-				end
+	for i = #entry.outbox, 1, -1 do
+		for _, deleted_msg in ipairs(msg_ids) do
+			if entry.outbox[i].id == deleted_msg then
+				table.remove(entry.outbox, i)
+				break
 			end
 		end
 	end
-	if #entry.drafts > 0 then
-		for i = #entry.drafts, 1, -1 do
-			for _, deleted_msg in ipairs(msg_ids) do
-				if entry.drafts[i].id == deleted_msg then
-					table.remove(entry.drafts, i)
-				end
+	for i = #entry.drafts, 1, -1 do
+		for _, deleted_msg in ipairs(msg_ids) do
+			if entry.drafts[i].id == deleted_msg then
+				table.remove(entry.drafts, i)
+				break
 			end
 		end
 	end


### PR DESCRIPTION
see discussion in #97 and #98 (the `break` just breaks out of the _inner_ loop, the messages still get iterated over)

for example this player-entry here:
```lua
local entry = {
 inbox = {
  { id = "a" },
  { id = "b" },
  { id = "c" }
 }
}
```

and if you want to delete messages with the following msg_id's:
```lua
msg_ids = { "c", "b" }
```

The mail with id `c` will get matched first and removed, after that the inbox looks like this:
```lua
inbox = {
  { id = "a" },
  { id = "b" }
}
```

But the inner loop still continues with the exact same `i` value and tries to dereference `inbox[3]` (which it does not find)

The break ensures that the `i` iterator value is actually sane and does point to a valid entry.