### PR TITLE
Store message list in context to improve performance

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -37,6 +37,13 @@ mail = {
 		trash_move_enable = {}
 	},
 
+	messages_context = {
+		inbox = {},
+		outbox = {},
+		drafts = {},
+		trash = {}
+	},
+
 	message_drafts = {}
 }
 

--- a/ui/drafts.lua
+++ b/ui/drafts.lua
@@ -24,8 +24,7 @@ function mail.show_drafts(name)
 		table[0,0.7;5.75,9.35;drafts;#999,]] .. S("To") .. "," .. S("Subject")
 
     local formspec = { drafts_formspec }
-    local entry = mail.get_storage_entry(name)
-    local messages = entry.drafts
+    local messages = mail.messages_context.drafts[name]
 
     mail.message_drafts[name] = nil
 

--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -9,9 +9,8 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
     filter = filter or mail.selected_idxs.filter[name] or ""
     mail.selected_idxs.inbox[name] = mail.selected_idxs.inbox[name] or {}
 
-    local entry = mail.get_storage_entry(name)
     local sortfield = ({"from","subject","time"})[sortfieldindex]
-    local messages = mail.sort_messages(entry.inbox, sortfield, sortdirection == "2", filter)
+    local messages = mail.sort_messages(mail.messages_context.inbox[name], sortfield, sortdirection == "2", filter)
 
     local trash_tab = ""
     if mail.get_setting(name, "trash_move_enable") then

--- a/ui/mail.lua
+++ b/ui/mail.lua
@@ -1,6 +1,13 @@
 -- helper function for tabbed overview
 
 function mail.show_mail_menu(playername, sortfield, sortdirection, filter)
+    -- create contexts
+    local entry = mail.get_storage_entry(playername)
+    mail.messages_context.inbox[playername] = mail.messages_context.inbox[playername] or entry.inbox
+    mail.messages_context.outbox[playername] = mail.messages_context.outbox[playername] or entry.outbox
+    mail.messages_context.drafts[playername] = mail.messages_context.drafts[playername] or entry.drafts
+    mail.messages_context.trash[playername] = mail.messages_context.trash[playername] or entry.trash
+
     local index = mail.selected_idxs.boxtab[playername] or 1
     if not mail.selected_idxs.boxtab[playername] then
         mail.selected_idxs.boxtab[playername] = 1

--- a/ui/outbox.lua
+++ b/ui/outbox.lua
@@ -9,9 +9,8 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
 	filter = filter or mail.selected_idxs.filter[name] or ""
     mail.selected_idxs.outbox[name] = mail.selected_idxs.outbox[name] or {}
 
-	local entry = mail.get_storage_entry(name)
 	local sortfield = ({"to","subject","time"})[sortfieldindex]
-    local messages = mail.sort_messages(entry.outbox, sortfield, sortdirection == "2", filter)
+    local messages = mail.sort_messages(mail.messages_context.outbox[name], sortfield, sortdirection == "2", filter)
 
     local trash_tab = ""
     if mail.get_setting(name, "trash_move_enable") then

--- a/ui/trash.lua
+++ b/ui/trash.lua
@@ -20,8 +20,7 @@ local trash_formspec = "size[8.5,10;]" .. mail.theme .. [[
 
 function mail.show_trash(name)
     local formspec = { trash_formspec }
-    local entry = mail.get_storage_entry(name)
-    local messages = entry.trash
+    local messages = mail.messages_context.trash[name]
 
     if messages[1] then
 		for _, message in ipairs(messages) do


### PR DESCRIPTION
I put that into WIP because I'm pretty sure there are many things to improve.

- They are deleted after closing formspec
- The json file is called only once
- It is regenerated after delete/restore/new message

I made a `mail.message_context` variable, following the concept of `selected_idxs`. I noticed small improvements while selecting messages in a big inbox, but let see (I did that with 2k messages instead of 4k the last time, cause it's too long).

To help you having better view of what I mean, you can add the following command from whosit :

```lua
local mail_spam = function(playername, param)
    local number = tonumber(param)
    if not number then
        number = 10
    end
    for i = 0, number do
        local success, err = mail.send({
                from = "singleplayer",
                to = playername,
                cc = "",
                bcc = "",
                subject = string.format("subject line %04d", i),
                body = "mail body test test"
        })
    end
end


minetest.register_chatcommand("mail_spam", {
    params = "",
    description = "Spam a mailbox of user with mails",
    privs = { server = true },
    func = mail_spam
})
```