### PR TITLE
Reworked settings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,6 @@
+-- translation
+local S = minetest.get_translator("mail")
+
 mail = {
 	-- version
 	version = 3,
@@ -52,18 +55,24 @@ mail = {
 	},
 
 	settings = {
-		chat_notifications = { type = "bool", default = true },
-		onjoin_notifications = { type = "bool", default = true },
-		hud_notifications = { type = "bool", default = true },
-		sound_notifications = { type = "bool", default = true },
-		unreadcolorenable = { type = "bool", default = true },
-		cccolorenable = { type = "bool", default = true },
-		defaultsortfield = { type = "number", default = 3 },
-		defaultsortdirection = { type = "number", default = 1 },
-		trash_move_enable = { type = "bool", default = true },
-		auto_marking_read = { type = "bool", default = true },
-		date_format = { type = "string", default = "%Y-%m-%d %X" },
+		chat_notifications		= { type = "bool",		default = true,				group = "notifications" },
+		onjoin_notifications	= { type = "bool",		default = true,				group = "notifications" },
+		hud_notifications		= { type = "bool",		default = true,				group = "notifications" },
+		sound_notifications		= { type = "bool",		default = true,				group = "notifications" },
+		unreadcolorenable		= { type = "bool",		default = true,				group = "message_list" },
+		cccolorenable			= { type = "bool",		default = true,				group = "message_list" },
+		defaultsortfield		= { type = "number",	default = 3,				group = "message_list" },
+		defaultsortdirection	= { type = "number",	default = 1,				group = "message_list" },
+		trash_move_enable		= { type = "bool",		default = true,				group = "other" },
+		auto_marking_read		= { type = "bool",		default = true,				group = "other" },
+		date_format				= { type = "string",	default = "%Y-%m-%d %X",	group = "other" },
 	},
+
+	settings_groups = {
+		notifications	= S("Notifications"),
+		message_list	= S("Message list"),
+		other			= S("Other")
+	}
 
 	message_drafts = {}
 }

--- a/init.lua
+++ b/init.lua
@@ -51,6 +51,20 @@ mail = {
 		new = "#00F529"
 	},
 
+	settings = {
+		chat_notifications = { type = "bool", default = true },
+		onjoin_notifications = { type = "bool", default = true },
+		hud_notifications = { type = "bool", default = true },
+		sound_notifications = { type = "bool", default = true },
+		unreadcolorenable = { type = "bool", default = true },
+		cccolorenable = { type = "bool", default = true },
+		defaultsortfield = { type = "number", default = 3 },
+		defaultsortdirection = { type = "number", default = 1 },
+		trash_move_enable = { type = "bool", default = true },
+		auto_marking_read = { type = "bool", default = true },
+		date_format = { type = "string", default = "%Y-%m-%d %X" },
+	},
+
 	message_drafts = {}
 }
 

--- a/init.lua
+++ b/init.lua
@@ -48,28 +48,49 @@ mail = {
 	},
 
 	settings = {
-		chat_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 1,
-		label = S("Chat notifications")				, tooltip = S("Receive a message in the chat when there is a new message") },
-		onjoin_notifications	= { type = "bool",		default = true,				group = "notifications",	index = 2,
-		label = S("On join notifications")			, tooltip = S("Receive a message at login when inbox isn't empty") },
-		hud_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 3,
-		label = S("HUD notifications")				, tooltip = S("Show an HUD notification when inbox isn't empty") },
-		sound_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 4,
-		label = S("Sound notifications")			, tooltip = S("Play a sound when there is a new message") },
-		unreadcolorenable		= { type = "bool",		default = true,				group = "message_list",		index = 1,
-		label = S("Show unread in different color") },
-		cccolorenable			= { type = "bool",		default = true,				group = "message_list",		index = 2,
-		label = S("Show CC/BCC in different color") },
-		defaultsortfield		= { type = "index",	default = 3,				group = "message_list",		index = 3,
-		label = S("Default sorting field")			, dataset = { S("From/To"), S("Subject"), S("Date") } },
-		defaultsortdirection	= { type = "index",	default = 1,				group = "message_list",		index = 4,
-		label = S("Default sorting direction")		, dataset = { S("Ascending"), S("Descending") } },
-		trash_move_enable		= { type = "bool",		default = true,				group = "other",		index = 1,
-		label = S("Move deleted messages to trash") },
-		auto_marking_read		= { type = "bool",		default = true,				group = "other",		index = 2,
-		label = S("Automatic marking read")			, tooltip = S("Mark a message as read when opened") },
-		date_format				= { type = "string",	default = "%Y-%m-%d %X",	group = "other",		index = 3,
-		label = S("Date format"),	dataset = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}, format = os.date },
+		chat_notifications = {
+			type = "bool", default = true, group = "notifications", index = 1,
+			label = S("Chat notifications"), tooltip = S("Receive a message in the chat when there is a new message")
+		},
+		onjoin_notifications = {
+			type = "bool", default = true, group = "notifications", index = 2,
+			label = S("On join notifications"), tooltip = S("Receive a message at login when inbox isn't empty") },
+		hud_notifications = {
+			type = "bool", default = true, group = "notifications", index = 3,
+			label = S("HUD notifications"), tooltip = S("Show an HUD notification when inbox isn't empty")
+		},
+		sound_notifications = {
+			type = "bool", default = true, group = "notifications", index = 4,
+			label = S("Sound notifications"), tooltip = S("Play a sound when there is a new message")
+		},
+		unreadcolorenable = {
+			type = "bool", default = true, group = "message_list", index = 1,
+			label = S("Show unread in different color")
+		},
+		cccolorenable = {
+			type = "bool", default = true, group = "message_list", index = 2,
+			label = S("Show CC/BCC in different color")
+		},
+		defaultsortfield = {
+			type = "index", default = 3, group = "message_list", index = 3,
+			label = S("Default sorting field"), dataset = { S("From/To"), S("Subject"), S("Date") }
+		},
+		defaultsortdirection = {
+			type = "index", default = 1, group = "message_list", index = 4,
+			label = S("Default sorting direction"), dataset = { S("Ascending"), S("Descending") }
+		},
+		trash_move_enable = {
+			type = "bool", default = true, group = "other", index = 1,
+			label = S("Move deleted messages to trash")
+		},
+		auto_marking_read = {
+			type = "bool", default = true, group = "other", index = 2,
+			label = S("Automatic marking read"), tooltip = S("Mark a message as read when opened")
+		},
+		date_format = {
+			type = "string", default = "%Y-%m-%d %X", group = "other", index = 3, label = S("Date format"),
+			dataset = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}, format = os.date
+		},
 	},
 
 	settings_groups = {

--- a/init.lua
+++ b/init.lua
@@ -31,14 +31,7 @@ mail = {
 		filter = {},
 		multipleselection = {},
 		optionstab = {},
-		chat_notifications = {},
-		onjoin_notifications = {},
-		hud_notifications = {},
-		sound_notifications = {},
-		unreadcolorenable = {},
-		cccolorenable = {},
-		trash_move_enable = {},
-		auto_marking_read = {},
+		settings_group = {},
 	},
 
 	colors = {
@@ -55,27 +48,42 @@ mail = {
 	},
 
 	settings = {
-		chat_notifications		= { type = "bool",		default = true,				group = "notifications" },
-		onjoin_notifications	= { type = "bool",		default = true,				group = "notifications" },
-		hud_notifications		= { type = "bool",		default = true,				group = "notifications" },
-		sound_notifications		= { type = "bool",		default = true,				group = "notifications" },
-		unreadcolorenable		= { type = "bool",		default = true,				group = "message_list" },
-		cccolorenable			= { type = "bool",		default = true,				group = "message_list" },
-		defaultsortfield		= { type = "number",	default = 3,				group = "message_list" },
-		defaultsortdirection	= { type = "number",	default = 1,				group = "message_list" },
-		trash_move_enable		= { type = "bool",		default = true,				group = "other" },
-		auto_marking_read		= { type = "bool",		default = true,				group = "other" },
-		date_format				= { type = "string",	default = "%Y-%m-%d %X",	group = "other" },
+		chat_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 1,
+		label = S("Chat notifications")				, tooltip = S("Receive a message in the chat when there is a new message") },
+		onjoin_notifications	= { type = "bool",		default = true,				group = "notifications",	index = 2,
+		label = S("On join notifications")			, tooltip = S("Receive a message at login when inbox isn't empty") },
+		hud_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 3,
+		label = S("HUD notifications")				, tooltip = S("Show an HUD notification when inbox isn't empty") },
+		sound_notifications		= { type = "bool",		default = true,				group = "notifications",	index = 4,
+		label = S("Sound notifications")			, tooltip = S("Play a sound when there is a new message") },
+		unreadcolorenable		= { type = "bool",		default = true,				group = "message_list",		index = 1,
+		label = S("Show unread in different color") },
+		cccolorenable			= { type = "bool",		default = true,				group = "message_list",		index = 2,
+		label = S("Show CC/BCC in different color") },
+		defaultsortfield		= { type = "index",	default = 3,				group = "message_list",		index = 3,
+		label = S("Default sorting field")			, dataset = { S("From/To"), S("Subject"), S("Date") } },
+		defaultsortdirection	= { type = "index",	default = 1,				group = "message_list",		index = 4,
+		label = S("Default sorting direction")		, dataset = { S("Ascending"), S("Descending") } },
+		trash_move_enable		= { type = "bool",		default = true,				group = "other",		index = 1,
+		label = S("Move deleted messages to trash") },
+		auto_marking_read		= { type = "bool",		default = true,				group = "other",		index = 2,
+		label = S("Automatic marking read")			, tooltip = S("Mark a message as read when opened") },
+		date_format				= { type = "string",	default = "%Y-%m-%d %X",	group = "other",		index = 3,
+		label = S("Date format"),	dataset = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}, format = os.date },
 	},
 
 	settings_groups = {
-		notifications	= S("Notifications"),
-		message_list	= S("Message list"),
-		other			= S("Other")
-	}
+		{ name = "notifications",	label = S("Notifications")},
+		{ name = "message_list",	label = S("Message list")},
+		{ name = "other",			label = S("Other")}
+	},
 
 	message_drafts = {}
 }
+
+for s, _ in pairs(mail.settings) do
+	mail.selected_idxs[s] = {}
+end
 
 if minetest.get_modpath("default") then
 	mail.theme = default.gui_bg .. default.gui_bg_img

--- a/init.lua
+++ b/init.lua
@@ -94,9 +94,9 @@ mail = {
 	},
 
 	settings_groups = {
-		{ name = "notifications",	label = S("Notifications")},
-		{ name = "message_list",	label = S("Message list")},
-		{ name = "other",			label = S("Other")}
+		{ name = "notifications", label = S("Notifications")},
+		{ name = "message_list",  label = S("Message list")},
+		{ name = "other",         label = S("Other")}
 	},
 
 	message_drafts = {}

--- a/storage.lua
+++ b/storage.lua
@@ -394,20 +394,7 @@ function mail.extractMaillists(receivers_string, maillists_owner)
 end
 
 function mail.get_setting_default_value(setting_name)
-	local default_values = {
-		chat_notifications = true,
-		onjoin_notifications = true,
-		hud_notifications = true,
-		sound_notifications = true,
-		unreadcolorenable = true,
-		cccolorenable = true,
-		defaultsortfield = 3,
-		defaultsortdirection = 1,
-		trash_move_enable = true,
-		auto_marking_read = true,
-		date_format = "%Y-%m-%d %X",
-	}
-	return default_values[setting_name]
+	return mail.settings[setting_name].default
 end
 
 function mail.get_setting(playername, setting_name)

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -3,21 +3,6 @@ local S = minetest.get_translator("mail")
 
 local FORMNAME = "mail:settings"
 
-local function deepcopy(orig)
-    local orig_type = type(orig)
-    local copy
-    if orig_type == 'table' then
-        copy = {}
-        for orig_key, orig_value in next, orig, nil do
-            copy[deepcopy(orig_key)] = deepcopy(orig_value)
-        end
-        setmetatable(copy, deepcopy(getmetatable(orig)))
-    else -- number, string, boolean, etc
-        copy = orig
-    end
-    return copy
-end
-
 function mail.show_settings(name)
     local groups_labels = {}
     local group_index = 1
@@ -82,7 +67,7 @@ function mail.show_settings(name)
                 ]]
             end
             if data.dataset then
-                local formatted_dataset = deepcopy(data.dataset)
+                local formatted_dataset = table.copy(data.dataset)
                 if data.format then
                     for i, d in ipairs(formatted_dataset) do
                         formatted_dataset[i] = data.format(d)
@@ -104,7 +89,7 @@ function mail.show_settings(name)
 
         elseif data.type == "index" then
             y = y + 0.55
-            local formatted_dataset = deepcopy(data.dataset)
+            local formatted_dataset = table.copy(data.dataset)
             if data.format then
                 for i, d in ipairs(formatted_dataset) do
                     formatted_dataset[i] = data.format(d)

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -62,9 +62,7 @@ function mail.show_settings(name)
             field_default .. [[]
             ]]
             if data.tooltip then
-                formspec = formspec .. [[
-                tooltip[]] .. setting .. ";" .. data.tooltip .. [[]
-                ]]
+                formspec = formspec .. "tooltip[" .. setting .. ";" .. data.tooltip .. "]"
             end
             if data.dataset then
                 local formatted_dataset = table.copy(data.dataset)

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -3,70 +3,127 @@ local S = minetest.get_translator("mail")
 
 local FORMNAME = "mail:settings"
 
-local date_formats = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}
+local function deepcopy(orig)
+    local orig_type = type(orig)
+    local copy
+    if orig_type == 'table' then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[deepcopy(orig_key)] = deepcopy(orig_value)
+        end
+        setmetatable(copy, deepcopy(getmetatable(orig)))
+    else -- number, string, boolean, etc
+        copy = orig
+    end
+    return copy
+end
 
 function mail.show_settings(name)
-    -- date formats prepare
-    local dates_now = {}
-    local previous_date_format = mail.get_setting(name, "date_format")
-    local date_dropdown_index = 1
-    for i, f in pairs(date_formats) do
-        table.insert(dates_now, os.date(f, os.time()))
-        if f == previous_date_format then date_dropdown_index = i end
+    local groups_labels = {}
+    local group_index = 1
+    mail.selected_idxs.settings_group[name] = mail.selected_idxs.settings_group[name] or mail.settings_groups[1].name
+    for i, g in ipairs(mail.settings_groups) do
+        table.insert(groups_labels, g.label)
+        if g.name == mail.selected_idxs.settings_group[name] then
+            group_index = i
+        end
     end
-    local date_dropdown_str = table.concat(dates_now, ",")
+    local groups_str = table.concat(groups_labels, ",")
 
 	local formspec = [[
 			size[10,6;]
 			tabheader[0.3,0.875;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;1;false;false]
 			button[9.35,0;0.75,0.5;back;X]
 
-			box[0,0.8;3,0.45;]] .. mail.colors.highlighted .. [[]
-			label[0.2,0.8;]] .. S("Notifications") .. [[]
-            checkbox[0,1.2;chat_notifications;]] .. S("Chat notifications") .. [[;]] ..
-            tostring(mail.get_setting(name, "chat_notifications")) .. [[]
-            checkbox[0,1.6;onjoin_notifications;]] .. S("On join notifications") .. [[;]] ..
-            tostring(mail.get_setting(name, "onjoin_notifications")) .. [[]
-            checkbox[0,2.0;hud_notifications;]] .. S("HUD notifications") .. [[;]] ..
-            tostring(mail.get_setting(name, "hud_notifications")) .. [[]
-            checkbox[0,2.4;sound_notifications;]] .. S("Sound notifications") .. [[;]] ..
-            tostring(mail.get_setting(name, "sound_notifications")) .. [[]
+			tablecolumns[text]
+            table[0,0.775;3,4.5;groups;]] .. groups_str .. [[;]] .. group_index .. [[]
 
-			box[5,0.8;3,0.45;]] .. mail.colors.highlighted .. [[]
-			label[5.2,0.8;]] .. S("Message list") .. [[]
-            checkbox[5,1.2;unreadcolorenable;]] .. S("Show unread in different color") .. [[;]] ..
-            tostring(mail.get_setting(name, "unreadcolorenable")) .. [[]
-            checkbox[5,1.6;cccolorenable;]] .. S("Show CC/BCC in different color") .. [[;]] ..
-            tostring(mail.get_setting(name, "cccolorenable")) .. [[]
-
-			label[5,2.6;]] .. S("Default sorting fields") .. [[]
-            dropdown[5.5,3.0;2,0.5;defaultsortfield;]] ..
-            S("From/To") .. "," .. S("Subject") .. "," .. S("Date") .. [[;]] ..
-            tostring(mail.get_setting(name, "defaultsortfield")) .. [[;true]
-            dropdown[7.5,3.0;2,0.5;defaultsortdirection;]] ..
-            S("Ascending") .. "," .. S("Descending") .. [[;]] ..
-            tostring(mail.get_setting(name, "defaultsortdirection")) .. [[;true]
-
-			box[0,3.2;3,0.45;]] .. mail.colors.highlighted .. [[]
-			label[0.2,3.2;]] .. S("Other") .. [[]
-            checkbox[0,3.6;trash_move_enable;]] .. S("Move deleted messages to trash") .. [[;]] ..
-            tostring(mail.get_setting(name, "trash_move_enable")) .. [[]
-            checkbox[0,4.0;auto_marking_read;]] .. S("Automatic marking read") .. [[;]] ..
-            tostring(mail.get_setting(name, "auto_marking_read")) .. [[]
-			label[0.31,4.7;]] .. S("Date format:") .. [[]
-            dropdown[2.7,4.6;4,0.5;date_format;]] .. date_dropdown_str .. [[;]] ..
-            tostring(date_dropdown_index) .. [[;true]
-
-            tooltip[chat_notifications;]] .. S("Receive a message in the chat when there is a new message") .. [[]
-            tooltip[onjoin_notifications;]] .. S("Receive a message at login when inbox isn't empty") .. [[]
-            tooltip[hud_notifications;]] .. S("Show an HUD notification when inbox isn't empty") .. [[]
-            tooltip[sound_notifications;]] .. S("Play a sound when there is a new message") .. [[]
-            tooltip[auto_marking_read;]] .. S("Mark a message as read when opened") .. [[]
+			box[3.5,0.8;3,0.45;]] .. mail.colors.highlighted .. [[]
+			label[3.7,0.8;]] .. mail.settings_groups[group_index].label .. [[]
 
             button[0,5.65;2.5,0.5;reset;]] .. S("Reset") .. [[]
             button[7.5,5.65;2.5,0.5;save;]] .. S("Save") .. [[]
-            ]] .. mail.theme
+            ]]
 
+    local x = 3.5
+    local y = 1
+    -- put settings in order
+    local ordered_settings = {}
+    for setting, data in pairs(mail.settings) do
+        if data.group == mail.selected_idxs.settings_group[name] then
+            table.insert(ordered_settings, setting)
+        end
+    end
+    table.sort(ordered_settings, function(a, b) return mail.settings[a].index < mail.settings[b].index end)
+    for _, setting in pairs(ordered_settings) do
+        local data = mail.settings[setting]
+        y = y + 0.4
+        local field_default = mail.selected_idxs[setting][name]
+        if field_default == nil then field_default = mail.get_setting(name, setting) end
+        if data.type == "bool" then
+            formspec = formspec .. [[
+            checkbox[]] .. x .. "," .. y .. ";" .. setting .. ";" ..
+            data.label .. ";" .. tostring(field_default) .. [[]
+            ]]
+            if data.tooltip then
+                formspec = formspec .. [[
+                tooltip[]] .. setting .. ";" .. data.tooltip .. [[]
+                ]]
+            end
+        elseif data.type == "string" then
+            y = y + 1
+            formspec = formspec .. [[
+            field[]] .. x+0.275 .. "," .. y .. ";3,0.5;" .. setting .. ";" .. data.label .. [[;]] ..
+            field_default .. [[]
+            ]]
+            if data.tooltip then
+                formspec = formspec .. [[
+                tooltip[]] .. setting .. ";" .. data.tooltip .. [[]
+                ]]
+            end
+            if data.dataset then
+                local formatted_dataset = deepcopy(data.dataset)
+                if data.format then
+                    for i, d in ipairs(formatted_dataset) do
+                        formatted_dataset[i] = data.format(d)
+                    end
+                end
+                local dataset_str = table.concat(formatted_dataset, ",")
+                local dataset_selected_id = 1
+                for i, d in ipairs(data.dataset) do
+                    if d == field_default then
+                        dataset_selected_id = i
+                        break
+                    end
+                end
+                formspec = formspec .. [[
+                dropdown[]] .. x+3 .. "," .. y-0.45 .. ";3,0.5;" .. "dataset_" .. setting .. ";" ..
+                dataset_str .. [[;]] .. dataset_selected_id .. [[;true]
+                ]]
+            end
+
+        elseif data.type == "index" then
+            y = y + 0.55
+            local formatted_dataset = deepcopy(data.dataset)
+            if data.format then
+                for i, d in ipairs(formatted_dataset) do
+                    formatted_dataset[i] = data.format(d)
+                end
+            end
+            local dataset_str = table.concat(formatted_dataset, ",")
+            local dataset_selected_id = field_default
+            formspec = formspec .. [[
+            dropdown[]] .. x .. "," .. y .. ";3,0.5;" .. setting .. ";" ..
+            dataset_str .. [[;]] .. dataset_selected_id .. [[;true]
+            ]]
+            if data.tooltip then
+                formspec = formspec .. [[
+                tooltip[]] .. setting .. ";" .. data.tooltip .. [[]
+                ]]
+            end
+        end
+    end
+    formspec = formspec .. mail.theme
 	minetest.show_formspec(name, FORMNAME, formspec)
 end
 
@@ -77,10 +134,30 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
     local playername = player:get_player_name()
 
+    for setting, data in pairs(mail.settings) do
+        if fields[setting] then
+            if data.type == "bool" then
+                mail.selected_idxs[setting][playername] = fields[setting] == "true"
+                break
+            elseif data.type == "string" then
+                if data.dataset and fields["dataset_" .. setting] then
+                    mail.selected_idxs[setting][playername] = data.dataset[tonumber(fields["dataset_" .. setting])]
+                end
+                mail.show_settings(playername)
+            elseif data.type == "index" then
+                mail.selected_idxs[setting][playername] = tonumber(fields[setting])
+            end
+        end
+    end
+
 	if fields.back then
 		mail.show_mail_menu(playername)
 		return
 
+    elseif fields.groups then
+        local evt = minetest.explode_table_event(fields.groups)
+        mail.selected_idxs.settings_group[playername] = mail.settings_groups[tonumber(evt.row)].name
+        mail.show_settings(playername)
     elseif fields.optionstab == "1" then
         mail.selected_idxs.optionstab[playername] = 1
 
@@ -89,47 +166,13 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
         mail.show_about(playername)
         return
 
-    elseif fields.chat_notifications then
-        mail.selected_idxs.chat_notifications[playername] = fields.chat_notifications == "true"
-
-    elseif fields.onjoin_notifications then
-        mail.selected_idxs.onjoin_notifications[playername] = fields.onjoin_notifications == "true"
-
-    elseif fields.hud_notifications then
-        mail.selected_idxs.hud_notifications[playername] = fields.hud_notifications == "true"
-
-    elseif fields.sound_notifications then
-        mail.selected_idxs.sound_notifications[playername] = fields.sound_notifications == "true"
-
-    elseif fields.unreadcolorenable then
-        mail.selected_idxs.unreadcolorenable[playername] = fields.unreadcolorenable == "true"
-
-    elseif fields.cccolorenable then
-        mail.selected_idxs.cccolorenable[playername] = fields.cccolorenable == "true"
-
-    elseif fields.trash_move_enable then
-        mail.selected_idxs.trash_move_enable[playername] = fields.trash_move_enable == "true"
-
-    elseif fields.auto_marking_read then
-        mail.selected_idxs.auto_marking_read[playername] = fields.auto_marking_read == "true"
-
     elseif fields.save then
-        -- checkboxes
-        mail.set_setting(playername, "chat_notifications", mail.selected_idxs.chat_notifications[playername])
-        mail.set_setting(playername, "onjoin_notifications", mail.selected_idxs.onjoin_notifications[playername])
-        mail.set_setting(playername, "hud_notifications", mail.selected_idxs.hud_notifications[playername])
-        mail.set_setting(playername, "sound_notifications", mail.selected_idxs.sound_notifications[playername])
-        mail.set_setting(playername, "unreadcolorenable", mail.selected_idxs.unreadcolorenable[playername])
-        mail.set_setting(playername, "cccolorenable", mail.selected_idxs.cccolorenable[playername])
-        mail.set_setting(playername, "trash_move_enable", mail.selected_idxs.trash_move_enable[playername])
-        mail.set_setting(playername, "auto_marking_read", mail.selected_idxs.auto_marking_read[playername])
-        -- dropdowns
-        local defaultsortfield = fields.defaultsortfield or mail.get_setting(playername, "defaultsortfield")
-        local defaultsortdirection = fields.defaultsortdirection or mail.get_setting(playername, "defaultsortdirection")
-        local date_format = date_formats[tonumber(fields.date_format)] or mail.get_setting(playername, "date_format")
-        mail.set_setting(playername, "defaultsortfield", tonumber(defaultsortfield))
-        mail.set_setting(playername, "defaultsortdirection", tonumber(defaultsortdirection))
-        mail.set_setting(playername, "date_format", date_format)
+        -- save settings
+        for setting, _ in pairs(mail.settings) do
+            local new_value = mail.selected_idxs[setting][playername]
+            if new_value == nil then new_value = mail.get_setting(playername, setting) end
+            mail.set_setting(playername, setting, new_value)
+        end
         -- update visuals
         mail.hud_update(playername, mail.get_storage_entry(playername).inbox)
         mail.show_settings(playername)
@@ -137,6 +180,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
     elseif fields.reset then
         mail.reset_settings(playername)
         mail.show_settings(playername)
-	end
+    end
 	return
 end)


### PR DESCRIPTION
This PR contains all from the new settings management. Let's explain a bit how it works :
- `init.lua` : here you defines the settings
  - `mail.settings` : the whole list of settings with `setting = { -- data }` structure
  - `mail.settings_groups` : the list of groups of settings (for settings page)
  - then it generates `selected_idxs` sub-tables for each settings
- `settings.lua` : the redesigned ui page
  - first of all, it defines a base of `x` and `y` values
  - after that, it creates a temporary table for ordering settings depending on their `index` value (for the selected group)
  - then it iterates through the settings and generate UI for each type of settings
  - when the player sends fields, it saves in `selected_idxs` the temporary value

Info for settings definition :
- required : `type` (supported : `string`, `index` (for dropdowns), `bool` (for checkboxes)), `default`, `group`, `label`
- additional : 
  - `index` (recommended) : used to defines the order of the settings in the group on the UI
  - `tooltip` : additional info at hovering
  - `dataset` :
    - required for `index` types (dropdown), for example default sorting field (From/To, ...)
    - using for giving predefined values for string (show a dropdown alongside)
  - `format` : for `dataset`, preview predefined values (for example format current date with `%X ...`)
  
Hope there's not too much bugs, I fixed all those I noticed. I'm surprised that it not contains too much new lines, and new settings implementation is now much easier.

And, as usual, a small screenshot : 
![screenshot_20230909_205628](https://github.com/mt-mods/mail/assets/75171564/a8a628f6-0947-4ecc-9885-d1fc1c3bd635)
