### PR TITLE
check if message is found in `mail.show_message`

### DIFF
--- a/ui/message.lua
+++ b/ui/message.lua
@@ -5,6 +5,11 @@ local FORMNAME = "mail:message"
 
 function mail.show_message(name, id)
 	local message = mail.get_message(name, id)
+	if not message then
+		-- message not found or vanished
+		return
+	end
+
 	mail.selected_idxs.message[name] = id
 
 	local formspec = [[


### PR DESCRIPTION
checks if the message to display is non-nil and skips the formspec part if it is nil

the cause of the `nil` messages could be some race-condition in the show/callback logic of the formspecs, until this is proven and can be reproduced this will fix #115 and any other nil-message related crash

