### PR TITLE
Add colors utilities

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -35,19 +35,6 @@ mail = {
 		settings_group = {},
 	},
 
-	colors = {
-		header = "#999",
-		selected = "#72FF63",
-		important = "#FFD700",
-		additional = "#CCCCDD",
-		imp_sel = "#B9EB32",
-		add_sel = "#9FE6A0",
-		imp_add = "#E6D26F",
-		imp_add_sel = "#BFE16B",
-		highlighted = "#608631",
-		new = "#00F529"
-	},
-
 	settings = {
 		chat_notifications = {
 			type = "bool", default = true, group = "notifications", index = 1,
@@ -113,6 +100,7 @@ end
 
 -- sub files
 local MP = minetest.get_modpath(minetest.get_current_modname())
+dofile(MP .. "/util/init.lua")
 dofile(MP .. "/chatcommands.lua")
 dofile(MP .. "/migrate.lua")
 dofile(MP .. "/hud.lua")
@@ -122,7 +110,6 @@ dofile(MP .. "/gui.lua")
 dofile(MP .. "/onjoin.lua")
 -- sub directories
 dofile(MP .. "/ui/init.lua")
-dofile(MP .. "/util/init.lua")
 
 -- migrate storage
 mail.migrate()

--- a/onjoin.lua
+++ b/onjoin.lua
@@ -17,7 +17,7 @@ minetest.register_on_joinplayer(function(player)
 
 		if unreadcount > 0 and mail.get_setting(name, "onjoin_notifications") then
 			minetest.chat_send_player(name,
-				minetest.colorize(mail.get_color("n"), "(" .. unreadcount .. ") " .. S("You have mail! Type /mail to read")))
+				minetest.colorize(mail.get_color("new"), "(" .. unreadcount .. ") " .. S("You have mail! Type /mail to read")))
 		end
 	end, player:get_player_name())
 end)

--- a/onjoin.lua
+++ b/onjoin.lua
@@ -17,7 +17,7 @@ minetest.register_on_joinplayer(function(player)
 
 		if unreadcount > 0 and mail.get_setting(name, "onjoin_notifications") then
 			minetest.chat_send_player(name,
-				minetest.colorize(mail.colors.new, "(" .. unreadcount .. ") " .. S("You have mail! Type /mail to read")))
+				minetest.colorize(mail.get_color("n"), "(" .. unreadcount .. ") " .. S("You have mail! Type /mail to read")))
 		end
 	end, player:get_player_name())
 end)

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -21,8 +21,8 @@ function mail.show_about(name)
 
 			tablecolumns[color;text;text]
 			table[5,0.75;4.9,5.5;contributors;]] ..
-			mail.colors.header .. [[,]] .. S("Contributors") .. [[,,]] ..
-			mail.colors.important .. [[,Cheapie,Initial idea/project,]] ..
+			mail.get_color("h") .. [[,]] .. S("Contributors") .. [[,,]] ..
+			mail.get_color("i") .. [[,Cheapie,Initial idea/project,]] ..
 			[[,Rubenwardy,Lua/UI improvements,]] ..
 			[[,BuckarooBanzay,Clean-ups\, Refactoring,]] ..
 			[[,Athozus,Boxes\, Maillists\, UI\, Settings,]] ..

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -21,8 +21,8 @@ function mail.show_about(name)
 
 			tablecolumns[color;text;text]
 			table[5,0.75;4.9,5.5;contributors;]] ..
-			mail.get_color("h") .. [[,]] .. S("Contributors") .. [[,,]] ..
-			mail.get_color("i") .. [[,Cheapie,Initial idea/project,]] ..
+			mail.get_color("header") .. [[,]] .. S("Contributors") .. [[,,]] ..
+			mail.get_color("important") .. [[,Cheapie,Initial idea/project,]] ..
 			[[,Rubenwardy,Lua/UI improvements,]] ..
 			[[,BuckarooBanzay,Clean-ups\, Refactoring,]] ..
 			[[,Athozus,Boxes\, Maillists\, UI\, Settings,]] ..

--- a/ui/contacts.lua
+++ b/ui/contacts.lua
@@ -9,7 +9,7 @@ local contacts_formspec = "size[8,9;]" .. mail.theme .. [[
 		button[6,1.60;2,0.5;delete;]] .. S("Delete") .. [[]
 		button[6,8.25;2,0.5;back;]] .. S("Back") .. [[]
 		tablecolumns[color;text;text]
-		table[0,0;5.75,9;contacts;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note")
+		table[0,0;5.75,9;contacts;]] .. mail.get_color("header") .. "," .. S("Name") .. "," .. S("Note")
 
 
 function mail.show_contacts(name)

--- a/ui/contacts.lua
+++ b/ui/contacts.lua
@@ -9,7 +9,7 @@ local contacts_formspec = "size[8,9;]" .. mail.theme .. [[
 		button[6,1.60;2,0.5;delete;]] .. S("Delete") .. [[]
 		button[6,8.25;2,0.5;back;]] .. S("Back") .. [[]
 		tablecolumns[color;text;text]
-		table[0,0;5.75,9;contacts;]] .. mail.colors.header .. "," .. S("Name") .. "," .. S("Note")
+		table[0,0;5.75,9;contacts;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note")
 
 
 function mail.show_contacts(name)

--- a/ui/drafts.lua
+++ b/ui/drafts.lua
@@ -21,7 +21,7 @@ function mail.show_drafts(name)
 		button_exit[6,9.5;2.5,0.5;quit;]] .. S("Close") .. [[]
 
 		tablecolumns[color;text;text]
-		table[0,0.7;5.75,9.35;drafts;]] .. mail.get_color("h") .. "," .. S("To") .. "," .. S("Subject")
+		table[0,0.7;5.75,9.35;drafts;]] .. mail.get_color("header") .. "," .. S("To") .. "," .. S("Subject")
 
     local formspec = { drafts_formspec }
     local entry = mail.get_storage_entry(name)

--- a/ui/drafts.lua
+++ b/ui/drafts.lua
@@ -21,7 +21,7 @@ function mail.show_drafts(name)
 		button_exit[6,9.5;2.5,0.5;quit;]] .. S("Close") .. [[]
 
 		tablecolumns[color;text;text]
-		table[0,0.7;5.75,9.35;drafts;]] .. mail.colors.header .. "," .. S("To") .. "," .. S("Subject")
+		table[0,0.7;5.75,9.35;drafts;]] .. mail.get_color("h") .. "," .. S("To") .. "," .. S("Subject")
 
     local formspec = { drafts_formspec }
     local entry = mail.get_storage_entry(name)

--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -67,7 +67,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
         button[3.5,9.5;2.5,0.5;selectall;]] .. S("(Un)select all") .. [[]
 
         tablecolumns[color;text;text]
-        table[0,0.7;5.75,7.45;inbox;]] .. mail.colors.header .. "," .. S("From") .. "," .. S("Subject")
+        table[0,0.7;5.75,7.45;inbox;]] .. mail.get_color("h") .. "," .. S("From") .. "," .. S("Subject")
     local formspec = { inbox_formspec }
 
     mail.message_drafts[name] = nil
@@ -90,27 +90,27 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
             if selected_id > 0 then
                 if not message.read and unread_color_enable then
                     if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.colors.imp_add_sel
+                        formspec[#formspec + 1] = "," .. mail.get_color("ias")
                     else
-                        formspec[#formspec + 1] = "," .. mail.colors.imp_sel
+                        formspec[#formspec + 1] = "," .. mail.get_color("is")
                     end
                 else
                     if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.colors.add_sel
+                        formspec[#formspec + 1] = "," .. mail.get_color("as")
                     else
-                        formspec[#formspec + 1] = "," .. mail.colors.selected
+                        formspec[#formspec + 1] = "," .. mail.get_color("s")
                     end
                 end
             else
                 if not message.read and unread_color_enable then
                     if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.colors.imp_add
+                        formspec[#formspec + 1] = "," .. mail.get_color("ia")
                     else
-                        formspec[#formspec + 1] = "," .. mail.colors.important
+                        formspec[#formspec + 1] = "," .. mail.get_color("i")
                     end
                 else
                     if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.colors.additional
+                        formspec[#formspec + 1] = "," .. mail.get_color("a")
                     else
                         formspec[#formspec + 1] = ","
                     end

--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -67,7 +67,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
         button[3.5,9.5;2.5,0.5;selectall;]] .. S("(Un)select all") .. [[]
 
         tablecolumns[color;text;text]
-        table[0,0.7;5.75,7.45;inbox;]] .. mail.get_color("h") .. "," .. S("From") .. "," .. S("Subject")
+        table[0,0.7;5.75,7.45;inbox;]] .. mail.get_color("header") .. "," .. S("From") .. "," .. S("Subject")
     local formspec = { inbox_formspec }
 
     mail.message_drafts[name] = nil
@@ -78,7 +78,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
     if #messages > 0 then
         for _, message in ipairs(messages) do
             local selected_id = 0
-            local displayed_color = ""
+            local displayed_color = {}
             -- check if message is in selection list and return its id
             if mail.selected_idxs.inbox[name] and #mail.selected_idxs.inbox[name] > 0 then
                 for i, selected_msg in ipairs(mail.selected_idxs.inbox[name]) do
@@ -89,13 +89,13 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
                 end
             end
             if selected_id > 0 then
-                displayed_color = displayed_color .. "s"
+                table.insert(displayed_color, "selected")
             end
             if not message.read and unread_color_enable then
-                displayed_color = displayed_color .. "i"
+                table.insert(displayed_color, "important")
             end
             if not mail.player_in_list(name, message.to) and cc_color_enable then
-                displayed_color = displayed_color .. "a"
+                table.insert(displayed_color, "additional")
             end
             formspec[#formspec + 1] = "," .. mail.get_color(displayed_color)
             formspec[#formspec + 1] = ","

--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -78,6 +78,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
     if #messages > 0 then
         for _, message in ipairs(messages) do
             local selected_id = 0
+            local displayed_color = ""
             -- check if message is in selection list and return its id
             if mail.selected_idxs.inbox[name] and #mail.selected_idxs.inbox[name] > 0 then
                 for i, selected_msg in ipairs(mail.selected_idxs.inbox[name]) do
@@ -88,34 +89,15 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
                 end
             end
             if selected_id > 0 then
-                if not message.read and unread_color_enable then
-                    if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.get_color("ias")
-                    else
-                        formspec[#formspec + 1] = "," .. mail.get_color("is")
-                    end
-                else
-                    if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.get_color("as")
-                    else
-                        formspec[#formspec + 1] = "," .. mail.get_color("s")
-                    end
-                end
-            else
-                if not message.read and unread_color_enable then
-                    if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.get_color("ia")
-                    else
-                        formspec[#formspec + 1] = "," .. mail.get_color("i")
-                    end
-                else
-                    if not mail.player_in_list(name, message.to) and cc_color_enable then
-                        formspec[#formspec + 1] = "," .. mail.get_color("a")
-                    else
-                        formspec[#formspec + 1] = ","
-                    end
-                end
+                displayed_color = displayed_color .. "s"
             end
+            if not message.read and unread_color_enable then
+                displayed_color = displayed_color .. "i"
+            end
+            if not mail.player_in_list(name, message.to) and cc_color_enable then
+                displayed_color = displayed_color .. "a"
+            end
+            formspec[#formspec + 1] = "," .. mail.get_color(displayed_color)
             formspec[#formspec + 1] = ","
             formspec[#formspec + 1] = minetest.formspec_escape(message.from)
             formspec[#formspec + 1] = ","

--- a/ui/maillists.lua
+++ b/ui/maillists.lua
@@ -9,7 +9,7 @@ local maillists_formspec = "size[8,9;]" .. mail.theme .. [[
 		button[6,1.60;2,0.5;delete;]] .. S("Delete") .. [[]
 		button[6,8.25;2,0.5;back;]] .. S("Back") .. [[]
 		tablecolumns[color;text;text]
-		table[0,0;5.75,9;maillists;]] .. mail.colors.header .. "," .. S("Name") .. "," .. S("Note")
+		table[0,0;5.75,9;maillists;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note")
 
 function mail.show_maillists(name)
 	local formspec = { maillists_formspec }

--- a/ui/maillists.lua
+++ b/ui/maillists.lua
@@ -9,7 +9,7 @@ local maillists_formspec = "size[8,9;]" .. mail.theme .. [[
 		button[6,1.60;2,0.5;delete;]] .. S("Delete") .. [[]
 		button[6,8.25;2,0.5;back;]] .. S("Back") .. [[]
 		tablecolumns[color;text;text]
-		table[0,0;5.75,9;maillists;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note")
+		table[0,0;5.75,9;maillists;]] .. mail.get_color("header") .. "," .. S("Name") .. "," .. S("Note")
 
 function mail.show_maillists(name)
 	local formspec = { maillists_formspec }

--- a/ui/message.lua
+++ b/ui/message.lua
@@ -15,7 +15,7 @@ function mail.show_message(name, id)
 	local formspec = [[
 			size[8,9]
 
-			box[0,0;7,1.9;]] .. mail.colors.highlighted .. [[]
+			box[0,0;7,1.9;]] .. mail.get_color("H") .. [[]
 
 			button[7.25,0.15;0.75,0.5;back;X]
 

--- a/ui/message.lua
+++ b/ui/message.lua
@@ -15,7 +15,7 @@ function mail.show_message(name, id)
 	local formspec = [[
 			size[8,9]
 
-			box[0,0;7,1.9;]] .. mail.get_color("H") .. [[]
+			box[0,0;7,1.9;]] .. mail.get_color("highlighted") .. [[]
 
 			button[7.25,0.15;0.75,0.5;back;X]
 

--- a/ui/outbox.lua
+++ b/ui/outbox.lua
@@ -73,6 +73,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
 	if #messages > 0 then
         for _, message in ipairs(messages) do
             local selected_id = 0
+            local displayed_color = ""
             -- check if message is in selection list and return its id
             if mail.selected_idxs.outbox[name] and #mail.selected_idxs.outbox[name] > 0 then
                 for i, selected_msg in ipairs(mail.selected_idxs.outbox[name]) do
@@ -83,10 +84,9 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
                 end
             end
             if selected_id > 0 then
-				formspec[#formspec + 1] = "," .. mail.get_color("s")
-            else
-				formspec[#formspec + 1] = ","
+                displayed_color = displayed_color .. "s"
             end
+            formspec[#formspec + 1] = "," .. mail.get_color(displayed_color)
             formspec[#formspec + 1] = ","
 			if string.len(message.to) > 20 then
 				formspec[#formspec + 1] = minetest.formspec_escape(string.sub(message.to, 1, 17))

--- a/ui/outbox.lua
+++ b/ui/outbox.lua
@@ -65,7 +65,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
         button[3.5,9.5;2.5,0.5;selectall;]] .. S("(Un)select all") .. [[]
 
 		tablecolumns[color;text;text]
-        table[0,0.7;5.75,7.45;outbox;]] .. mail.get_color("h") .. "," .. S("To") .. "," .. S("Subject")
+        table[0,0.7;5.75,7.45;outbox;]] .. mail.get_color("header") .. "," .. S("To") .. "," .. S("Subject")
 	local formspec = { outbox_formspec }
 
 	mail.message_drafts[name] = nil
@@ -73,7 +73,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
 	if #messages > 0 then
         for _, message in ipairs(messages) do
             local selected_id = 0
-            local displayed_color = ""
+            local displayed_color = {}
             -- check if message is in selection list and return its id
             if mail.selected_idxs.outbox[name] and #mail.selected_idxs.outbox[name] > 0 then
                 for i, selected_msg in ipairs(mail.selected_idxs.outbox[name]) do
@@ -84,7 +84,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
                 end
             end
             if selected_id > 0 then
-                displayed_color = displayed_color .. "s"
+                table.insert(displayed_color, "selected")
             end
             formspec[#formspec + 1] = "," .. mail.get_color(displayed_color)
             formspec[#formspec + 1] = ","

--- a/ui/outbox.lua
+++ b/ui/outbox.lua
@@ -65,7 +65,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
         button[3.5,9.5;2.5,0.5;selectall;]] .. S("(Un)select all") .. [[]
 
 		tablecolumns[color;text;text]
-        table[0,0.7;5.75,7.45;outbox;]] .. mail.colors.header .. "," .. S("To") .. "," .. S("Subject")
+        table[0,0.7;5.75,7.45;outbox;]] .. mail.get_color("h") .. "," .. S("To") .. "," .. S("Subject")
 	local formspec = { outbox_formspec }
 
 	mail.message_drafts[name] = nil
@@ -83,7 +83,7 @@ function mail.show_outbox(name, sortfieldindex, sortdirection, filter)
                 end
             end
             if selected_id > 0 then
-				formspec[#formspec + 1] = "," .. mail.colors.selected
+				formspec[#formspec + 1] = "," .. mail.get_color("s")
             else
 				formspec[#formspec + 1] = ","
             end

--- a/ui/receivers.lua
+++ b/ui/receivers.lua
@@ -9,7 +9,7 @@ function mail.show_receivers(name, id)
 	local formspec = [[
 			size[8,6]
 
-			box[0,0;7,1.1;]] .. mail.get_color("H") .. [[]
+			box[0,0;7,1.1;]] .. mail.get_color("highlighted") .. [[]
 
 			button[7.25,0.15;0.75,0.5;back;X]
 
@@ -25,10 +25,10 @@ function mail.show_receivers(name, id)
 
 	local from = minetest.formspec_escape(message.from) or ""
 	local to = mail.parse_player_list(message.to or "")
-	local to_str = mail.get_color("h") .. "," .. S("To") .. ",,"
+	local to_str = mail.get_color("header") .. "," .. S("To") .. ",,"
 	to_str = to_str .. table.concat(to, ",,")
 	local cc = mail.parse_player_list(message.cc or "")
-	local cc_str = mail.get_color("h") .. "," .. S("CC") .. ",,"
+	local cc_str = mail.get_color("header") .. "," .. S("CC") .. ",,"
 	cc_str = cc_str .. table.concat(cc, ",,")
 	local date = type(message.time) == "number"
 		and minetest.formspec_escape(os.date(mail.get_setting(name, "date_format"), message.time)) or ""

--- a/ui/receivers.lua
+++ b/ui/receivers.lua
@@ -9,7 +9,7 @@ function mail.show_receivers(name, id)
 	local formspec = [[
 			size[8,6]
 
-			box[0,0;7,1.1;]] .. mail.colors.highlighted .. [[]
+			box[0,0;7,1.1;]] .. mail.get_color("H") .. [[]
 
 			button[7.25,0.15;0.75,0.5;back;X]
 
@@ -25,10 +25,10 @@ function mail.show_receivers(name, id)
 
 	local from = minetest.formspec_escape(message.from) or ""
 	local to = mail.parse_player_list(message.to or "")
-	local to_str = mail.colors.header .. "," .. S("To") .. ",,"
+	local to_str = mail.get_color("h") .. "," .. S("To") .. ",,"
 	to_str = to_str .. table.concat(to, ",,")
 	local cc = mail.parse_player_list(message.cc or "")
-	local cc_str = mail.colors.header .. "," .. S("CC") .. ",,"
+	local cc_str = mail.get_color("h") .. "," .. S("CC") .. ",,"
 	cc_str = cc_str .. table.concat(cc, ",,")
 	local date = type(message.time) == "number"
 		and minetest.formspec_escape(os.date(mail.get_setting(name, "date_format"), message.time)) or ""

--- a/ui/select_contact.lua
+++ b/ui/select_contact.lua
@@ -5,15 +5,15 @@ local FORMNAME = "mail:selectcontact"
 
 local select_contact_formspec = "size[8,9;]" .. mail.theme .. [[
     tablecolumns[color;text;text]
-    table[0,0;3.5,9;contacts;]] .. mail.colors.header .. "," .. S("Name") .. "," .. S("Note") .. [[%s]
+    table[0,0;3.5,9;contacts;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note") .. [[%s]
     button[3.55,2.00;1.75,0.5;toadd;→ ]] .. S("Add") .. [[]
     button[3.55,2.75;1.75,0.5;toremove;← ]] .. S("Remove") .. [[]
     button[3.55,6.00;1.75,0.5;ccadd;→ ]] .. S("Add") .. [[]
     button[3.55,6.75;1.75,0.5;ccremove;← ]] .. S("Remove") .. [[]
     tablecolumns[color;text;text]
-    table[5.15,0.0;2.75,4.5;to;]] .. mail.colors.header .. "," .. S("To") .. ":," .. S("Note") .. [[%s]
+    table[5.15,0.0;2.75,4.5;to;]] .. mail.get_color("h") .. "," .. S("To") .. ":," .. S("Note") .. [[%s]
     tablecolumns[color;text;text]
-    table[5.15,4.6;2.75,4.5;cc;]] .. mail.colors.header .. "," .. S("CC") .. ":," .. S("Note") .. [[%s]
+    table[5.15,4.6;2.75,4.5;cc;]] .. mail.get_color("h") .. "," .. S("CC") .. ":," .. S("Note") .. [[%s]
     button[3.55,8.25;1.75,0.5;back;]] .. S("Back") .. [[]
 ]]
 

--- a/ui/select_contact.lua
+++ b/ui/select_contact.lua
@@ -5,15 +5,15 @@ local FORMNAME = "mail:selectcontact"
 
 local select_contact_formspec = "size[8,9;]" .. mail.theme .. [[
     tablecolumns[color;text;text]
-    table[0,0;3.5,9;contacts;]] .. mail.get_color("h") .. "," .. S("Name") .. "," .. S("Note") .. [[%s]
+    table[0,0;3.5,9;contacts;]] .. mail.get_color("header") .. "," .. S("Name") .. "," .. S("Note") .. [[%s]
     button[3.55,2.00;1.75,0.5;toadd;→ ]] .. S("Add") .. [[]
     button[3.55,2.75;1.75,0.5;toremove;← ]] .. S("Remove") .. [[]
     button[3.55,6.00;1.75,0.5;ccadd;→ ]] .. S("Add") .. [[]
     button[3.55,6.75;1.75,0.5;ccremove;← ]] .. S("Remove") .. [[]
     tablecolumns[color;text;text]
-    table[5.15,0.0;2.75,4.5;to;]] .. mail.get_color("h") .. "," .. S("To") .. ":," .. S("Note") .. [[%s]
+    table[5.15,0.0;2.75,4.5;to;]] .. mail.get_color("header") .. "," .. S("To") .. ":," .. S("Note") .. [[%s]
     tablecolumns[color;text;text]
-    table[5.15,4.6;2.75,4.5;cc;]] .. mail.get_color("h") .. "," .. S("CC") .. ":," .. S("Note") .. [[%s]
+    table[5.15,4.6;2.75,4.5;cc;]] .. mail.get_color("header") .. "," .. S("CC") .. ":," .. S("Note") .. [[%s]
     button[3.55,8.25;1.75,0.5;back;]] .. S("Back") .. [[]
 ]]
 

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -23,7 +23,7 @@ function mail.show_settings(name)
 			tablecolumns[text]
             table[0,0.775;3,4.5;groups;]] .. groups_str .. [[;]] .. group_index .. [[]
 
-			box[3.5,0.8;3,0.45;]] .. mail.colors.highlighted .. [[]
+			box[3.5,0.8;3,0.45;]] .. mail.get_color("H") .. [[]
 			label[3.7,0.8;]] .. mail.settings_groups[group_index].label .. [[]
 
             button[0,5.65;2.5,0.5;reset;]] .. S("Reset") .. [[]

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -23,7 +23,7 @@ function mail.show_settings(name)
 			tablecolumns[text]
             table[0,0.775;3,4.5;groups;]] .. groups_str .. [[;]] .. group_index .. [[]
 
-			box[3.5,0.8;3,0.45;]] .. mail.get_color("H") .. [[]
+			box[3.5,0.8;3,0.45;]] .. mail.get_color("highlighted") .. [[]
 			label[3.7,0.8;]] .. mail.settings_groups[group_index].label .. [[]
 
             button[0,5.65;2.5,0.5;reset;]] .. S("Reset") .. [[]

--- a/ui/trash.lua
+++ b/ui/trash.lua
@@ -16,7 +16,7 @@ local trash_formspec = "size[8.5,10;]" .. mail.theme .. [[
 	button_exit[6,9.5;2.5,0.5;quit;]] .. S("Close") .. [[]
 
 	tablecolumns[color;text;text]
-	table[0,0.7;5.75,9.35;trash;]] .. mail.get_color("h") .. "," .. S("From/To") .. "," .. S("Subject")
+	table[0,0.7;5.75,9.35;trash;]] .. mail.get_color("header") .. "," .. S("From/To") .. "," .. S("Subject")
 
 
 function mail.show_trash(name)

--- a/ui/trash.lua
+++ b/ui/trash.lua
@@ -16,7 +16,7 @@ local trash_formspec = "size[8.5,10;]" .. mail.theme .. [[
 	button_exit[6,9.5;2.5,0.5;quit;]] .. S("Close") .. [[]
 
 	tablecolumns[color;text;text]
-	table[0,0.7;5.75,9.35;trash;]] .. mail.colors.header .. "," .. S("From/To") .. "," .. S("Subject")
+	table[0,0.7;5.75,9.35;trash;]] .. mail.get_color("h") .. "," .. S("From/To") .. "," .. S("Subject")
 
 
 function mail.show_trash(name)

--- a/util/colors.lua
+++ b/util/colors.lua
@@ -1,6 +1,6 @@
 local function get_base_color(id)
     local colors = {
-		h = "#999", -- header
+		h = "#999999", -- header
 		s = "#72FF63", -- selected
 		i = "#FFD700", -- important
 		a = "#CCCCDD", -- additional

--- a/util/colors.lua
+++ b/util/colors.lua
@@ -32,9 +32,9 @@ local function rgbColorsMix(colors)
         G = G + c.g
         B = B + c.b
     end
-    R = R / #colors
-    G = G / #colors
-    B = B / #colors
+    R = math.floor(R / #colors + 0.5)
+    G = math.floor(G / #colors + 0.5)
+    B = math.floor(B / #colors + 0.5)
     return {r=R,g=G,b=B}
 end
 

--- a/util/colors.lua
+++ b/util/colors.lua
@@ -1,0 +1,53 @@
+local function get_base_color(id)
+    local colors = {
+		h = "#999", -- header
+		s = "#72FF63", -- selected
+		i = "#FFD700", -- important
+		a = "#CCCCDD", -- additional
+		H = "#608631", -- highlighted
+		n = "#00F529" -- new
+	}
+	return colors[id]
+end
+
+local function hex2rgb(hex)
+    hex = hex:gsub("#","")
+    return {
+        r = tonumber("0x" .. hex:sub(1,2)),
+        g = tonumber("0x" .. hex:sub(3,4)),
+        b = tonumber("0x" .. hex:sub(5,6))
+    }
+end
+
+local function rgb2hex(rgb)
+    return "#" .. string.format("%x", rgb.r) .. string.format("%x", rgb.g) .. string.format("%x", rgb.b)
+end
+
+local function rgbColorsMix(colors)
+    local R = 0
+    local G = 0
+    local B = 0
+    for _, c in ipairs(colors) do
+        R = R + c.r
+        G = G + c.g
+        B = B + c.b
+    end
+    R = R / #colors
+    G = G / #colors
+    B = B / #colors
+    return {r=R,g=G,b=B}
+end
+
+function mail.get_color(mix)
+    if #mix == 1 then
+        return get_base_color(mix)
+    else
+        local colors = {}
+        for i = 1, #mix do
+            local c = mix:sub(i,i)
+            colors[#colors+1] = hex2rgb(get_base_color(c))
+        end
+        local mixed_color = rgbColorsMix(colors)
+        return rgb2hex(mixed_color)
+    end
+end

--- a/util/colors.lua
+++ b/util/colors.lua
@@ -1,13 +1,14 @@
-local function get_base_color(id)
-    local colors = {
-		h = "#999999", -- header
-		s = "#72FF63", -- selected
-		i = "#FFD700", -- important
-		a = "#CCCCDD", -- additional
-		H = "#608631", -- highlighted
-		n = "#00F529" -- new
-	}
-	return colors[id]
+local generic_colors = {
+	header         = "#999999",
+	selected       = "#72FF63",
+	important      = "#FFD700",
+	additional     = "#CCCCDD",
+	highlighted    = "#608631",
+	new            = "#00F529",
+}
+
+local function get_base_color(c)
+    return generic_colors[c] or ""
 end
 
 local function hex2rgb(hex)
@@ -39,15 +40,16 @@ local function rgbColorsMix(colors)
 end
 
 function mail.get_color(mix)
-    if #mix == 1 then
+    if type(mix) == "string" then
         return get_base_color(mix)
+    elseif #mix == 1 then
+        return get_base_color(mix[1])
     else
-        local colors = {}
-        for i = 1, #mix do
-            local c = mix:sub(i,i)
-            colors[#colors+1] = hex2rgb(get_base_color(c))
+        local colors2mix = {}
+        for _, c in ipairs(mix) do
+            colors2mix[#colors2mix+1] = hex2rgb(get_base_color(c))
         end
-        local mixed_color = rgbColorsMix(colors)
+        local mixed_color = rgbColorsMix(colors2mix)
         return rgb2hex(mixed_color)
     end
 end

--- a/util/init.lua
+++ b/util/init.lua
@@ -1,6 +1,7 @@
 -- sub files
 local MP = minetest.get_modpath(minetest.get_current_modname())
 dofile(MP .. "/util/normalize.lua")
+dofile(MP .. "/util/colors.lua")
 dofile(MP .. "/util/contact.lua")
 dofile(MP .. "/util/uuid.lua")
 dofile(MP .. "/util/time_ago.lua")


### PR DESCRIPTION
This is a rework of mail colors. It is a prerequisite for #102, as the addition of it will add many colors. So, it has the following changes : 
- Remove colors from `init.lua`
- Add an utility file `/util/colors.lua`
- Only one global function `mail.get_color()` which returns a color from mixed base colors. It overpasses the mix if there is only one color given.
- Local function `get_base_color()`. The inheritor of `init.lua`. It uses shortcuts of one letter to be simplified and notably for the use of `mail.get_color()`. Of course, comments to tell what is what.
- Local functions to convert from hex to rgb and vice-versa.
- Local function to mix rgb colors.
- EDIT : and, of course, it replaces all the previous occurrences of `mail.colors`

An example of use : 
- Old : `mail.colors.imp_add_sel`
- New : `mail.get_color("ias")`, `mail.get_color("sai")` ...

You can note that the new utility is independent from order.

NB : I wrote the whole code in less than 1 hour, so the review should be quick =)