### PR TITLE
Use interleaved style

### DIFF
--- a/ui/message.lua
+++ b/ui/message.lua
@@ -4,12 +4,7 @@ local S = minetest.get_translator("mail")
 local FORMNAME = "mail:message"
 
 local function interleaveMsg(body)
-	local lines = (body or ""):split("\n", true)
-	local il_lines = {}
-	for _,l in ipairs(lines) do
-		il_lines[#il_lines+1] = "> " .. l
-	end
-	return table.concat(il_lines, "\n")
+	return "> " .. (body or ""):gsub("\n", "\n> ")
 end
 
 

--- a/ui/message.lua
+++ b/ui/message.lua
@@ -3,6 +3,16 @@ local S = minetest.get_translator("mail")
 
 local FORMNAME = "mail:message"
 
+local function interleaveMsg(body)
+	local lines = (body or ""):split("\n", true)
+	local il_lines = {}
+	for _,l in ipairs(lines) do
+		il_lines[#il_lines+1] = "> " .. l
+	end
+	return table.concat(il_lines, "\n")
+end
+
+
 function mail.show_message(name, id)
 	local message = mail.get_message(name, id)
 	if not message then
@@ -65,8 +75,7 @@ function mail.reply(name, message)
 		minetest.log("error", "[mail] current mail-context: " .. dump(mail.selected_idxs))
 		return
 	end
-	local replyfooter = "Type your reply here.\n\n--Original message follows--\n" ..message.body
-	mail.show_compose(name, message.from, "Re: "..message.subject, replyfooter)
+	mail.show_compose(name, message.from, "Re: "..message.subject, interleaveMsg(message.body))
 end
 
 function mail.replyall(name, message)
@@ -76,8 +85,6 @@ function mail.replyall(name, message)
 		minetest.log("error", "[mail] current mail-context: " .. dump(mail.selected_idxs))
 		return
 	end
-
-	local replyfooter = "Type your reply here.\n\n--Original message follows--\n" ..message.body
 
 	-- new recipients are the sender plus the original recipients, minus ourselves
 	local recipients = message.to or ""
@@ -103,12 +110,11 @@ function mail.replyall(name, message)
 	end
 	cc = mail.concat_player_list(cc)
 
-	mail.show_compose(name, recipients, "Re: "..message.subject, replyfooter, cc)
+	mail.show_compose(name, recipients, "Re: "..message.subject, interleaveMsg(message.body), cc)
 end
 
 function mail.forward(name, message)
-	local fwfooter = "Type your message here.\n\n--Original message follows--\n" .. (message.body or "")
-	mail.show_compose(name, "", "Fw: " .. (message.subject or ""), fwfooter)
+	mail.show_compose(name, "", "Fw: " .. (message.subject or ""), interleaveMsg(message.body))
 end
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)


### PR DESCRIPTION
As suggested in #120 by @nonfreegithub, I made a small script to generate interleaved style by putting `>` chars before each new line.

I'm making a pull request in case some features/details are requested, notably for formspec visualization, even if it's hard, if it's a well-demanded feature, then I can work on it.

Note that it uses a local function `interleaveMsg()`, because the code is shared for both replying (all)/forwarding.

I let you a screenshot anyway.
![screenshot_20231207_220431](https://github.com/mt-mods/mail/assets/75171564/d24cf023-69f8-4244-8bc7-5982981c033a)

