### PR TITLE
Implement non-player recipients

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -10,6 +10,11 @@ function mail.register_on_receive(func)
 	mail.registered_on_receives[#mail.registered_on_receives + 1] = func
 end
 
+mail.registered_on_player_receives = {}
+function mail.register_on_player_receive(func)
+	table.insert(mail.registered_on_player_receives, func)
+end
+
 mail.registered_recipient_handlers = {}
 function mail.register_recipient_handler(func)
 	table.insert(mail.registered_recipient_handlers, func)

--- a/api.md
+++ b/api.md
@@ -34,11 +34,18 @@ local success, error = mail.send({
 ```
 
 # Hooks
-On-receive mail hook:
+Generic on-receive mail hook:
 
 ```lua
 mail.register_on_receive(function(m)
 	-- "m" is an object in the form: "Mail format"
+end)
+```
+
+Player-specific on-receive mail hook:
+```lua
+mail.register_on_player_receive(function(player, msg)
+    -- "player" is the name of a recipient; "msg" is a mail object (see "Mail format")
 end)
 ```
 

--- a/api.md
+++ b/api.md
@@ -42,6 +42,22 @@ mail.register_on_receive(function(m)
 end)
 ```
 
+# Recipient handler
+Recipient handlers are registered using
+
+```lua
+mail.register_recipient_handler(function(sender, name)
+end)
+```
+
+where `name` is the name of a single recipient.
+
+The recipient handler should return
+* `nil` if the handler does not handle messages sent to the particular recipient,
+* `true, player` (where `player` is a string or a list of strings) if the mail should be redirected to `player`,
+* `true, deliver` if the mail should be delivered by calling `deliver` with the message, or
+* `false, reason` (where `reason` is optional or, if provided, a string) if the recipient explicitly rejects the mail.
+
 # Internals
 
 mod-storage entry for a player (indexed by playername and serialized with json):

--- a/api.spec.lua
+++ b/api.spec.lua
@@ -1,12 +1,43 @@
+mtt.register("register non-player-recipients", function(callback)
+    mail.register_recipient_handler(function(sender, name)
+        if name:sub(1, 6) == "alias/" then
+            return true, name:sub(7)
+        elseif name == "list/test" then
+            return true, {"alias/player1", "alias/player2"}
+        elseif name == "list/reject" then
+            return false, "It works (?)"
+        end
+    end)
+end
+
+local function assert_inbox_count(player_name, count)
+    local entry == mail.get_storage_entry(player_name)
+    assert(entry, player_name .. " has no mail entry")
+    local actual_count = #entry.inbox
+    assert(actual_count == count, ("incorrect mail count: %d expected, got %d"):format(count, actual_count))
+end
+
 mtt.register("send mail", function(callback)
-    -- send a mail
-    local success, err = mail.send({from = "player1", to = "player2", subject = "something", body = "blah"})
+    -- send a mail to a list
+    local success, err = mail.send({from = "player1", to = "list/test", subject = "something", body = "blah"})
     assert(success)
     assert(not err)
+    assert_inbox_count("player2", 1)
+    assert_inbox_count("player1", 0)
 
-    -- check the receivers inbox
-    local entry = mail.get_storage_entry("player2")
-    assert(entry)
-    assert(#entry.inbox > 0)
+    -- send a second mail to the list and also the sender
+    success, err = mail.send({from = "player1", to = "list/test, alias/player1", subject = "something", body = "blah"})
+    assert(success)
+    assert(not err)
+    assert_inbox_count("player2", 2)
+    assert_inbox_count("player1", 1)
+
+    -- send a mail to list/reject - the mail should be rejected
+    success, err = mail.send({from = "player1", to = "list/reject", subject = "something", body = "NO"})
+    assert(not success)
+    assert(type(err) == "string")
+    assert_inbox_count("player2", 2)
+    assert_inbox_count("player1", 1)
+
     callback()
 end)

--- a/api.spec.lua
+++ b/api.spec.lua
@@ -8,11 +8,23 @@ mail.register_recipient_handler(function(_, name)
     end
 end)
 
+local received_count = {}
+mail.register_on_player_receive(function(player)
+	received_count[player] = (received_count[player] or 0) + 1
+end)
+
+local sent_count = 0
+mail.register_on_receive(function()
+	sent_count = sent_count+1
+end)
+
 local function assert_inbox_count(player_name, count)
     local entry = mail.get_storage_entry(player_name)
     assert(entry, player_name .. " has no mail entry")
     local actual_count = #entry.inbox
     assert(actual_count == count, ("incorrect mail count: %d expected, got %d"):format(count, actual_count))
+    local player_received = received_count[player_name]
+    assert(player_received == count, ("incorrect receive count: %d expected, got %d"):format(count, player_received))
 end
 
 mtt.register("send mail", function(callback)
@@ -22,6 +34,7 @@ mtt.register("send mail", function(callback)
     assert(not err)
     assert_inbox_count("player2", 1)
     assert_inbox_count("player1", 0)
+    assert(sent_count == 1)
 
     -- send a second mail to the list and also the sender
     success, err = mail.send({from = "player1", to = "list/test, alias/player1", subject = "something", body = "blah"})
@@ -29,6 +42,7 @@ mtt.register("send mail", function(callback)
     assert(not err)
     assert_inbox_count("player2", 2)
     assert_inbox_count("player1", 1)
+    assert(sent_count == 2)
 
     -- send a mail to list/reject - the mail should be rejected
     success, err = mail.send({from = "player1", to = "list/reject", subject = "something", body = "NO"})
@@ -36,6 +50,7 @@ mtt.register("send mail", function(callback)
     assert(type(err) == "string")
     assert_inbox_count("player2", 2)
     assert_inbox_count("player1", 1)
+    assert(sent_count == 2)
 
     callback()
 end)

--- a/api.spec.lua
+++ b/api.spec.lua
@@ -1,17 +1,15 @@
-mtt.register("register non-player-recipients", function(callback)
-    mail.register_recipient_handler(function(sender, name)
-        if name:sub(1, 6) == "alias/" then
-            return true, name:sub(7)
-        elseif name == "list/test" then
-            return true, {"alias/player1", "alias/player2"}
-        elseif name == "list/reject" then
-            return false, "It works (?)"
-        end
-    end)
-end
+mail.register_recipient_handler(function(_, name)
+    if name:sub(1, 6) == "alias/" then
+        return true, name:sub(7)
+    elseif name == "list/test" then
+        return true, {"alias/player1", "alias/player2"}
+    elseif name == "list/reject" then
+        return false, "It works (?)"
+    end
+end)
 
 local function assert_inbox_count(player_name, count)
-    local entry == mail.get_storage_entry(player_name)
+    local entry = mail.get_storage_entry(player_name)
     assert(entry, player_name .. " has no mail entry")
     local actual_count = #entry.inbox
     assert(actual_count == count, ("incorrect mail count: %d expected, got %d"):format(count, actual_count))

--- a/api.spec.lua
+++ b/api.spec.lua
@@ -23,7 +23,7 @@ local function assert_inbox_count(player_name, count)
     assert(entry, player_name .. " has no mail entry")
     local actual_count = #entry.inbox
     assert(actual_count == count, ("incorrect mail count: %d expected, got %d"):format(count, actual_count))
-    local player_received = received_count[player_name]
+    local player_received = received_count[player_name] or 0
     assert(player_received == count, ("incorrect receive count: %d expected, got %d"):format(count, player_received))
 end
 

--- a/init.lua
+++ b/init.lua
@@ -49,6 +49,7 @@ dofile(MP .. "/storage.lua")
 dofile(MP .. "/api.lua")
 dofile(MP .. "/gui.lua")
 dofile(MP .. "/onjoin.lua")
+dofile(MP .. "/player_recipients.lua")
 -- sub directories
 dofile(MP .. "/ui/init.lua")
 

--- a/player_recipients.lua
+++ b/player_recipients.lua
@@ -1,7 +1,7 @@
 local S = minetest.get_translator("mail")
 local has_canonical_name = minetest.get_modpath("canonical_name")
 
-local function deliver_mail_to_player(name, msg)
+mail.register_on_player_receive(function(name, msg)
 	-- add to inbox
 	local entry = mail.get_storage_entry(name)
 	table.insert(entry.inbox, msg)
@@ -26,14 +26,18 @@ local function deliver_mail_to_player(name, msg)
 		local receiver_messages = receiver_entry.inbox
 		mail.hud_update(name, receiver_messages)
 	end
-end
+end)
 
 mail.register_recipient_handler(function(_, pname)
 	if not minetest.player_exists(pname) then
 		return nil
 	end
-	return true, function(mail)
-		deliver_mail_to_player(pname, mail)
+	return true, function(msg)
+		for _, on_player_receive in ipairs(mail.registered_on_player_receives) do
+			if on_player_receive(pname, msg) then
+				break
+			end
+		end
 	end
 end)
 

--- a/player_recipients.lua
+++ b/player_recipients.lua
@@ -1,0 +1,47 @@
+local S = minetest.get_translator("mail")
+local has_canonical_name = minetest.get_modpath("canonical_name")
+
+local function deliver_mail_to_player(name, msg)
+	-- add to inbox
+	local entry = mail.get_storage_entry(name)
+	table.insert(entry.inbox, msg)
+	mail.set_storage_entry(name, entry)
+
+	-- notify recipients that happen to be online
+	local mail_alert = S("You have a new message from @1! Subject: @2",  msg.from, msg.subject) ..
+	"\n" .. S("To view it, type /mail")
+	local inventory_alert = S("You could also use the button in your inventory.")
+	local player = minetest.get_player_by_name(name)
+	if player then
+		if mail.get_setting(name, "chat_notifications") == true then
+			minetest.chat_send_player(name, mail_alert)
+			if minetest.get_modpath("unified_inventory") or minetest.get_modpath("sfinv_buttons") then
+				minetest.chat_send_player(name, inventory_alert)
+			end
+		end
+		if mail.get_setting(name, "sound_notifications") == true then
+			minetest.sound_play("mail_notif", {to_player=name})
+		end
+		local receiver_entry = mail.get_storage_entry(name)
+		local receiver_messages = receiver_entry.inbox
+		mail.hud_update(name, receiver_messages)
+	end
+end
+
+mail.register_recipient_handler(function(_, pname)
+	if not minetest.player_exists(pname) then
+		return nil
+	end
+	return true, function(mail)
+		deliver_mail_to_player(pname, mail)
+	end
+end)
+
+if has_canonical_name then
+	mail.register_recipient_handler(function(_, name)
+		local realname = canonical_name.get(name)
+		if realname then
+			return true, realname
+		end
+	end)
+end

--- a/util/normalize.lua
+++ b/util/normalize.lua
@@ -13,7 +13,7 @@ local function recursive_expand_recipient_names(sender, list, is_toplevel, recip
             local vtp = type(value)
             if succ then
                 if vtp == "string" then
-                    recursive_expand_recipient_names(sender, {value}, false, recipients, undeliverable)
+                    recursive_expand_recipient_names(sender, {value}, is_toplevel, recipients, undeliverable)
                 elseif vtp == "table" then
                     recursive_expand_recipient_names(sender, value, false, recipients, undeliverable)
                 elseif vtp == "function" then

--- a/util/normalize.spec.lua
+++ b/util/normalize.spec.lua
@@ -2,7 +2,7 @@
 mtt.register("util/normalize_players_and_add_recipients", function(callback)
     local recipients = {}
     local undeliverable = {}
-    local to = mail.normalize_players_and_add_recipients("player1,player2", recipients, undeliverable)
+    local to = mail.normalize_players_and_add_recipients("sender", "player1,player2", recipients, undeliverable)
 
     assert(to == "player1, player2")
     assert(not next(undeliverable))


### PR DESCRIPTION
This PR allows sending mail to non-player recipients.

There are some potential usecases for this PR:
* Interaction with automated systems (e.g. remote control)
* Mailing lists; in particular, it could allow (for example) sending messages to all members of a beerchat channel, which can be useful for (for public channels) announcements or (for private channels) internal communication without having to keep track of the members.

Checklist:
- [x] Implement recipient handlers
- [x] Properly handle sending mail to the sender:
  - The sender should not receive mail addressed to a list if the sender is not otherwise listed as a recipient.
  - The sender may send mail to an alias (and should also receive it)
- [x] Add a callback for a player receiving mail (as opposed to a mail being sent)
- [x] Add tests

(I hope I did not miss anything important.)

<details><summary>Advtrains</summary>
<p>

For people into Advtrains, I put together a simple patch for Advtrains as a proof-of-concept for what can be done with this PR. The patch below allows
* sending ATC commands to a train (note the protection code - the mail is rejected if the sender does not have permission to control the train)
* sending mail to subscribers of a LuaATC environment, which can be useful for communicating certain changes to the code.

```diff
diff --git a/advtrains/init.lua b/advtrains/init.lua
index a7e5764..d1a605c 100644
--- a/advtrains/init.lua
+++ b/advtrains/init.lua
@@ -222,6 +222,7 @@ dofile(advtrains.modpath.."/craft_items.lua")
 
 dofile(advtrains.modpath.."/log.lua")
 dofile(advtrains.modpath.."/passive.lua")
+dofile(advtrains.modpath.."/mail.lua")
 if mesecon then
 	dofile(advtrains.modpath.."/p_mesecon_iface.lua")
 end
diff --git a/advtrains/mail.lua b/advtrains/mail.lua
new file mode 100644
index 0000000..6c0c48b
--- /dev/null
+++ b/advtrains/mail.lua
@@ -0,0 +1,19 @@
+if mail and mail.register_recipient_handler then
+	mail.register_recipient_handler(function(sender, recipient)
+		local tid = string.match(recipient, "^advtrains/train/(.+)$")
+		if tid and advtrains.trains[tid] then
+			local train = advtrains.trains[tid]
+			for _, wid in ipairs(train.trainparts) do
+				local wagon = advtrains.wagons[wid]
+				if not advtrains.check_driving_couple_protection(sender, wagon.owner, wagon.whitelist) then
+					return false, attrans("You do not have permission to operate the train @1", tid)
+				end
+			end
+			return true, function(msg)
+				if msg.subject == "ATC" then
+					advtrains.atc.train_set_command(train, msg.body)
+				end
+			end
+		end
+	end)
+end
diff --git a/advtrains/mod.conf b/advtrains/mod.conf
index 5808d1a..34c5fad 100644
--- a/advtrains/mod.conf
+++ b/advtrains/mod.conf
@@ -4,4 +4,4 @@ description=Core system for realistic trains in Minetest
 author=orwell96
 
 depends=serialize_lib
-optional_depends=mesecons,mesecons_switch,digtron
+optional_depends=mesecons,mesecons_switch,digtron,mail
diff --git a/advtrains_luaautomation/environment.lua b/advtrains_luaautomation/environment.lua
index d85bedc..c1685df 100644
--- a/advtrains_luaautomation/environment.lua
+++ b/advtrains_luaautomation/environment.lua
@@ -376,6 +376,12 @@ function atlatc.run_initcode()
 	end
 end
 
-
-
-
+--- mail interface
+if mail and mail.register_recipient_handler then
+	mail.register_recipient_handler(function(_, pname)
+		local envname = string.match(pname, "atlatc/subscribers/(.+)")
+		if envname and atlatc.envs[envname] then
+			return true, atlatc.envs[envname].subscribers
+		end
+	end)
+end
diff --git a/advtrains_luaautomation/mod.conf b/advtrains_luaautomation/mod.conf
index a737603..2fc210d 100644
--- a/advtrains_luaautomation/mod.conf
+++ b/advtrains_luaautomation/mod.conf
@@ -4,4 +4,4 @@ description=Lua control interface to Advanced Trains
 author=orwell96
 
 depends=advtrains
-optional_depends=advtrains_interlocking,advtrains_line_automation,mesecons_switch
+optional_depends=advtrains_interlocking,advtrains_line_automation,mesecons_switch,mail

```

</p>
</details> 