### PR TITLE
evict cached storage entries periodically

### DIFF
--- a/storage.lua
+++ b/storage.lua
@@ -61,6 +61,9 @@ local function save_worker()
 	-- clear queue
 	save_queued_entries = {}
 
+	-- clear cached entries
+	cache = {}
+
 	-- save every second
 	minetest.after(1, save_worker)
 end


### PR DESCRIPTION
fixes synchronization issues if other applications write directly to the mail-entries in the mod-storage