### PR TITLE
Cleanly handle player mailling lists

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -51,6 +51,8 @@ function mail.send(m)
 			table.insert(undeliverable_reason, reason)
 		end
 		return false, table.concat(undeliverable_reason, "\n")
+	elseif not next(recipients) then
+		return false, S("You did not specify any valid recipient.")
 	end
 
 	local extra = {}

--- a/api.spec.lua
+++ b/api.spec.lua
@@ -7,6 +7,12 @@ mail.register_recipient_handler(function(_, name)
         return false, "It works (?)"
     end
 end)
+mail.update_maillist("player1", {
+	owner = "player1",
+	name = "recursive",
+	desc = "",
+	players = {"@recursive", "player1"},
+}, "recursive")
 
 local received_count = {}
 mail.register_on_player_receive(function(player)
@@ -27,30 +33,44 @@ local function assert_inbox_count(player_name, count)
     assert(player_received == count, ("incorrect receive count: %d expected, got %d"):format(count, player_received))
 end
 
+local function assert_send(expected_success, ...)
+	local success, err = mail.send(...)
+	if expected_success then
+		assert(success, ("expected mail to be sent, got error message: %s"):format(err))
+		assert(not err, ("unexpected message after sending mail: %s"):format(err))
+	else
+		assert(not success, "expected mail to be rejected, mail was sent")
+		assert(type(err) == "string", ("expected error message, got datum of type %s"):format(type(err)))
+	end
+end
+
 mtt.register("send mail", function(callback)
-    -- send a mail to a list
-    local success, err = mail.send({from = "player1", to = "list/test", subject = "something", body = "blah"})
-    assert(success)
-    assert(not err)
-    assert_inbox_count("player2", 1)
-    assert_inbox_count("player1", 0)
+    -- local maillists
+    assert_send(true, {from = "player1", to = "@recursive", subject = "hello recursion", body = "blah"})
+    assert_inbox_count("player1", 1)
     assert(sent_count == 1)
 
-    -- send a second mail to the list and also the sender
-    success, err = mail.send({from = "player1", to = "list/test, alias/player1", subject = "something", body = "blah"})
-    assert(success)
-    assert(not err)
-    assert_inbox_count("player2", 2)
+    -- do not allow empty recipients
+    assert_send(false, {from = "player1", to = "@doesnotexist", subject = "should not be sent", body = "blah"})
+    assert(sent_count == 1)
+
+    -- send a mail to a list
+    assert_send(true, {from = "player1", to = "list/test", subject = "something", body = "blah"})
+    assert_inbox_count("player2", 1)
     assert_inbox_count("player1", 1)
     assert(sent_count == 2)
 
-    -- send a mail to list/reject - the mail should be rejected
-    success, err = mail.send({from = "player1", to = "list/reject", subject = "something", body = "NO"})
-    assert(not success)
-    assert(type(err) == "string")
+    -- send a second mail to the list and also the sender
+    assert_send(true, {from = "player1", to = "list/test, alias/player1", subject = "something", body = "blah"})
     assert_inbox_count("player2", 2)
-    assert_inbox_count("player1", 1)
-    assert(sent_count == 2)
+    assert_inbox_count("player1", 2)
+    assert(sent_count == 3)
+
+    -- send a mail to list/reject - the mail should be rejected
+    assert_send(false, {from = "player1", to = "list/reject", subject = "something", body = "NO"})
+    assert_inbox_count("player2", 2)
+    assert_inbox_count("player1", 2)
+    assert(sent_count == 3)
 
     callback()
 end)


### PR DESCRIPTION
Fixes #138.

Also addresses https://github.com/mt-mods/mail/issues/138#issuecomment-2004769746 by not allowing players to send the mail if there is no valid recipient.