### PR TITLE
Adjusted options UI

### DIFF
--- a/ui/about.lua
+++ b/ui/about.lua
@@ -6,21 +6,33 @@ local FORMNAME = "mail:about"
 function mail.show_about(name)
 	local formspec = [[
 			size[10,6;]
-			tabheader[0.3,0.875;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;2;false;false]
+			tabheader[0,0;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;2;false;false]
 			button[9.35,0;0.75,0.5;back;X]
-			label[0,0.7;Mail]
-			label[0,1.1;]] .. S("Provided by mt-mods") .. [[]
-			label[0,1.5;]] .. S("Version") .. [[ : 1.4.0-dev]
-			label[0,2.0;]] .. S("Licenses") .. [[ :]
-			label[0.2,2.4;]] .. S("Expat (code), WTFPL (textures)") .. [[]
-			label[0,3.2;https://github.com/mt-mods/mail]
-			label[0,3.6;https://content.minetest.net/packages/mt-mods/mail]
-			textarea[0.5,4.8;4,5.5;;]] .. S("Note") .. [[;]] ..
+
+			box[0,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
+			label[0.2,0;Mail]
+
+			label[0.2,0.5;]] .. S("Provided by mt-mods") .. [[]
+			label[0.2,0.9;]] .. S("Version") .. [[ : 1.4.0-dev]
+
+			box[0,1.5;3,0.45;]] .. mail.get_color("highlighted") .. [[]
+			label[0.2,1.5;]] .. S("Licenses") .. [[]
+			label[0.2,2.0;]] .. S("Expat (code), WTFPL (textures)") .. [[]
+
+			box[0,2.6;3,0.45;]] .. mail.get_color("highlighted") .. [[]
+			label[0.2,2.6;]] .. S("Note") .. [[]
+			textarea[0.5,3.1;4,5.5;;;]] ..
 			S("Communication using this system is NOT guaranteed to be private!") .. " " ..
 			S("Admins are able to view the messages of any player.") .. [[]
 
+			button[0,5.7;2,0.5;github;GitHub]
+			button[2,5.7;2,0.5;contentdb;ContentDB]
+
+			box[4,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
+			label[4.2,0;]] .. S("Contributors") .. [[]
+
 			tablecolumns[color;text;text]
-			table[5,0.75;4.9,5.5;contributors;]] ..
+			table[4,0.75;5.9,5.5;contributors;]] ..
 			mail.get_color("header") .. [[,]] .. S("Contributors") .. [[,,]] ..
 			mail.get_color("important") .. [[,Cheapie,Initial idea/project,]] ..
 			[[,Rubenwardy,Lua/UI improvements,]] ..
@@ -66,5 +78,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
     elseif fields.optionstab == "2" then
         mail.selected_idxs.optionstab[playername] = 2
         mail.show_about(playername)
+
+	elseif fields.github then
+		minetest.chat_send_player(playername, "https://github.com/mt-mods/mail")
+
+	elseif fields.contentdb then
+		minetest.chat_send_player(playername, "https://content.minetest.net/packages/mt-mods/mail")
 	end
 end)

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -71,21 +71,19 @@ function mail.show_about(name)
 			box[4,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
 			label[4.2,0;]] .. S("Contributors") .. [[]
 
-			tablecolumns[text;text;text;text;text;text]
+			tablecolumns[text;text]
 			table[4,0.75;5.9,5.5;contributors;]]
 
 	for _, c in ipairs(contributors) do
-		formspec = formspec .. c.name .. ","
+		formspec = formspec .. c.name
 		for _, g in ipairs(groups) do
 			if table.indexof(c.groups, g[1]) >= 1 then
-				formspec = formspec .. string.upper(g[1]) .. ","
+				formspec = formspec .. "," .. g[2] .. ","
 			end
-		end
-		for _ = 1, (#groups-#c.groups) do
-			formspec = formspec .. ","
 		end
 	end
 
+	formspec = string.sub(formspec, 2, -2) -- remove last blank line
 	formspec = formspec .. mail.theme
 
 	minetest.show_formspec(name, FORMNAME, formspec)

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -3,6 +3,46 @@ local S = minetest.get_translator("mail")
 
 local FORMNAME = "mail:about"
 
+local groups = {
+	{ "o", S("Original author")},
+	{ "c", S("Code")},
+	{ "i", S("Internationalization")},
+	{ "t", S("Textures")},
+	{ "a", S("Audio")},
+}
+
+local contributors = {
+	{ name = "Cheapie", groups = {"o", "c"} },
+	{ name = "aBlueShadow", groups = {"c"} },
+	{ name = "APercy", groups = {"i"} },
+	{ name = "Athozus", groups = {"c", "i"} },
+	{ name = "BuckarooBanzay", groups = {"c"} },
+	{ name = "Chache", groups = {"i"} },
+	{ name = "Dennis Jenkins", groups = {"c"} },
+	{ name = "Emojigit", groups = {"i"} },
+	{ name = "Eredin", groups = {"i"} },
+	{ name = "fluxionary", groups = {"c"} },
+	{ name = "imre84", groups = {"c"} },
+	{ name = "Muhammad Rifqi Priyo Susanto", groups = {"i"} },
+	{ name = "NatureFreshMilk", groups = {"c", "t"} },
+	{ name = "Niklp", groups = {"c", "i"} },
+	{ name = "Nuno Filipe Povoa", groups = {"a"} },
+	{ name = "nyomi", groups = {"i"} },
+	{ name = "OgelGames", groups = {"c"} },
+	{ name = "Panquesito7", groups = {"c"} },
+	{ name = "Peter Nerlich", groups = {"c"} },
+	{ name = "Rubenwardy", groups = {"c"} },
+	{ name = "savilli", groups = {"c"} },
+	{ name = "Singularis", groups = {"c"} },
+	{ name = "SX", groups = {"c"} },
+	{ name = "TheTrueBeginner", groups = {"i"} },
+	{ name = "Thomas Rudin", groups = {"c"} },
+	{ name = "Toby1710", groups = {"c"} },
+	{ name = "whosit", groups = {"c"} },
+	{ name = "Wuzzy", groups = {"i"} },
+	{ name = "y5nw", groups = {"c", "i"} },
+}
+
 function mail.show_about(name)
 	local formspec = [[
 			size[10,6;]
@@ -31,32 +71,22 @@ function mail.show_about(name)
 			box[4,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
 			label[4.2,0;]] .. S("Contributors") .. [[]
 
-			tablecolumns[color;text;text]
-			table[4,0.75;5.9,5.5;contributors;]] ..
-			mail.get_color("header") .. [[,]] .. S("Contributors") .. [[,,]] ..
-			mail.get_color("important") .. [[,Cheapie,Initial idea/project,]] ..
-			[[,Rubenwardy,Lua/UI improvements,]] ..
-			[[,BuckarooBanzay,Clean-ups\, Refactoring,]] ..
-			[[,Athozus,Boxes\, Maillists\, UI\, Settings,]] ..
-			[[,fluxionary,Minor fixups,]] ..
-			[[,SX,Various fixes\, UI,]] ..
-			[[,Toby1710,UX fixes,]] ..
-			[[,Peter Nerlich,CC\, BCC,]] ..
-			[[,Niklp,German translation,]] ..
-			[[,Emojigit,Traditional Chinese trans.,]] ..
-			[[,Dennis Jenkins,UX fixes,]] ..
-			[[,Thomas Rudin,Maintenance,]] ..
-			[[,NatureFreshMilk,Maintenance,]] ..
-			[[,imre84,UI fixes,]] ..
-			[[,Chache,Spanish translation,]] ..
-			[[,APercy,Brazilian Portuguese trans.,]] ..
-			[[,Nuno Filipe Povoa,mail_notif.ogg,]] ..
-			[[,TheTrueBeginner,Simplified Chinese trans.,]] ..
-			[[,nyomi,Hungarian translation,]] ..
-			[[,whosit,UI fixes,]] ..
-			[[,Wuzzy,German translation,]] ..
-			[[,Muhammad Rifqi Priyo Susanto,Indonesian trans.]
-		]] .. mail.theme
+			tablecolumns[text;text;text;text;text;text]
+			table[4,0.75;5.9,5.5;contributors;]]
+
+	for _, c in ipairs(contributors) do
+		formspec = formspec .. c.name .. ","
+		for _, g in ipairs(groups) do
+			if table.indexof(c.groups, g[1]) >= 1 then
+				formspec = formspec .. string.upper(g[1]) .. ","
+			end
+		end
+		for _ = 1, (#groups-#c.groups) do
+			formspec = formspec .. ","
+		end
+	end
+
+	formspec = formspec .. mail.theme
 
 	minetest.show_formspec(name, FORMNAME, formspec)
 end

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -53,7 +53,7 @@ function mail.show_about(name)
 			label[0.2,0;Mail]
 
 			label[0.2,0.5;]] .. S("Provided by mt-mods") .. [[]
-			label[0.2,0.9;]] .. S("Version: @1", "1.4.0-dev") .. [[
+			label[0.2,0.9;]] .. S("Version: @1", "1.4.0-dev") .. [[]
 
 			box[0,1.5;3,0.45;]] .. mail.get_color("highlighted") .. [[]
 			label[0.2,1.5;]] .. S("Licenses") .. [[]

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -53,7 +53,7 @@ function mail.show_about(name)
 			label[0.2,0;Mail]
 
 			label[0.2,0.5;]] .. S("Provided by mt-mods") .. [[]
-			label[0.2,0.9;]] .. S("Version") .. [[ : 1.4.0-dev]
+			label[0.2,0.9;]] .. S("Version: @1", "1.4.0-dev") .. [[
 
 			box[0,1.5;3,0.45;]] .. mail.get_color("highlighted") .. [[]
 			label[0.2,1.5;]] .. S("Licenses") .. [[]

--- a/ui/about.lua
+++ b/ui/about.lua
@@ -43,7 +43,9 @@ local contributors = {
 	{ name = "y5nw", groups = {"c", "i"} },
 }
 
-function mail.show_about(name)
+function mail.show_about(name, contributor_grouping)
+	contributor_grouping = tonumber(contributor_grouping) or 1
+
 	local formspec = [[
 			size[10,6;]
 			tabheader[0,0;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;2;false;false]
@@ -69,21 +71,50 @@ function mail.show_about(name)
 			button[2,5.7;2,0.5;contentdb;ContentDB]
 
 			box[4,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
-			label[4.2,0;]] .. S("Contributors") .. [[]
+			label[4.2,0;]] .. S("Contributors") .. "]" ..
 
-			tablecolumns[text;text]
-			table[4,0.75;5.9,5.5;contributors;]]
+			("dropdown[4,0.75;6.4;contributor_grouping;%s,%s;%d;true]"):format(
+					S("Group by name"), S("Group by contribution"), contributor_grouping)
 
-	for _, c in ipairs(contributors) do
-		formspec = formspec .. c.name
+	local contributor_list, contributor_columns = {}
+
+	if contributor_grouping == 2 then
+		contributor_columns = "color;text"
+		local sorted = {}
 		for _, g in ipairs(groups) do
-			if table.indexof(c.groups, g[1]) >= 1 then
-				formspec = formspec .. "," .. g[2] .. ","
+			sorted[g[1]] = {}
+		end
+		for _, c in ipairs(contributors) do
+			for _, g in ipairs(c.groups) do
+				table.insert(sorted[g] or {}, c.name)
+			end
+		end
+		for _, g in ipairs(groups) do
+			table.insert(contributor_list, mail.get_color("header") .. "," .. g[2])
+			for _, c in ipairs(sorted[g[1]]) do
+				table.insert(contributor_list, "," .. c)
+			end
+		end
+	else
+		contributor_columns = "text;text"
+		for _, c in ipairs(contributors) do
+			for _, g in ipairs(groups) do
+				local index = table.indexof(c.groups, g[1])
+				if index >= 1 then
+					if index == 1 then
+						table.insert(contributor_list, c.name)
+					else
+						table.insert(contributor_list, "")
+					end
+					table.insert(contributor_list, g[2])
+				end
 			end
 		end
 	end
 
-	formspec = string.sub(formspec, 2, -2) -- remove last blank line
+	formspec = formspec .. ("tablecolumns[%s]"):format(contributor_columns) ..
+			("table[4,1.6;5.9,4.65;contributors;%s]"):format(table.concat(contributor_list, ","))
+
 	formspec = formspec .. mail.theme
 
 	minetest.show_formspec(name, FORMNAME, formspec)
@@ -112,5 +143,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	elseif fields.contentdb then
 		minetest.chat_send_player(playername, "https://content.minetest.net/packages/mt-mods/mail")
+	elseif fields.contributor_grouping then
+		mail.show_about(playername, fields.contributor_grouping)
 	end
 end)

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -17,21 +17,21 @@ function mail.show_settings(name)
 
 	local formspec = [[
 			size[10,6;]
-			tabheader[0.3,0.875;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;1;false;false]
+			tabheader[0,0;optionstab;]] .. S("Settings") .. "," .. S("About") .. [[;1;false;false]
 			button[9.35,0;0.75,0.5;back;X]
 
 			tablecolumns[text]
             table[0,0.775;3,4.5;groups;]] .. groups_str .. [[;]] .. group_index .. [[]
 
-			box[3.5,0.8;3,0.45;]] .. mail.get_color("highlighted") .. [[]
-			label[3.7,0.8;]] .. mail.settings_groups[group_index].label .. [[]
+			box[0,0;3,0.45;]] .. mail.get_color("highlighted") .. [[]
+			label[0.2,0;]] .. mail.settings_groups[group_index].label .. [[]
 
             button[0,5.65;2.5,0.5;reset;]] .. S("Reset") .. [[]
             button[7.5,5.65;2.5,0.5;save;]] .. S("Save") .. [[]
             ]]
 
     local x = 3.5
-    local y = 1
+    local y = -0.6
     -- put settings in order
     local ordered_settings = {}
     for setting, data in pairs(mail.settings) do


### PR DESCRIPTION
This pull request does :
* adjust settings layout [figure 1]
* adjust about layout [figure 2]
* improve contributors list by displaying codes (will become soon icons, when we'll find a pixel artist) + updated list [figure 2]
* GH/CDB buttons send their url in the chat to be Ctrl+clicked

It is not really essential but it gives more space for settings, as I will increase soon the number of settings.

![screenshot_20240322_234324](https://github.com/mt-mods/mail/assets/75171564/4b97a5fa-81c3-49e7-abc8-4b99e4b01d38)
![screenshot_20240328_175230](https://github.com/mt-mods/mail/assets/75171564/d4d8e6f1-0744-4e7d-9edb-89ba5273f68e)
