### PR TITLE
Implement grouping by contribution type

### DIFF
--- a/ui/about.lua
+++ b/ui/about.lua
@@ -76,7 +76,7 @@ function mail.show_about(name, contributor_grouping)
 			("dropdown[4,0.75;6.4;contributor_grouping;%s,%s;%d;true]"):format(
 					S("Group by name"), S("Group by contribution"), contributor_grouping)
 
-	local contributor_columns, contributor_list = "", {}
+	local contributor_list, contributor_columns = {}
 
 	if contributor_grouping == 2 then
 		contributor_columns = "color;text"


### PR DESCRIPTION
*Note: this is a proposed addition to #141, which is why this PR uses `improved-options-ui` as the based branch instead of `master`.*

This preserves the current mode as the default where the contributor list is displayed as `| Name | Contribution |`, but adds a new mode that shows contributors as a list grouped by the type of contribution (see screenshot)

![2024-03-30-23-05-22](https://github.com/mt-mods/mail/assets/37980625/87f375c9-a67a-4b8b-b8b3-7006077bee99)

---

On a less related note, IMO the formspecs should be modified to use real coordinates in the future.