### PR TITLE
Repair UUIDs duplicates (storage 3.1 upgrade)

### DIFF
--- a/migrate.lua
+++ b/migrate.lua
@@ -91,17 +91,15 @@ end
 
 local function is_uuid_existing(uuid)
     for _, k in ipairs(mail.storage:get_keys()) do
-        if string.sub(k,1,5) ~= "mail/" then
-            goto continue
-        end
-        local p = string.sub(k, 6)
-        local result
-        local boxes = {"inbox", "outbox", "drafts", "trash"}
-        for _, b in ipairs(boxes) do
-			result = search_box(p, b, uuid)
-			if result then return result end
+        if string.sub(k,1,5) == "mail/" then
+			local p = string.sub(k, 6)
+			local result
+			local boxes = {"inbox", "outbox", "drafts", "trash"}
+			for _, b in ipairs(boxes) do
+				result = search_box(p, b, uuid)
+				if result then return result end
+			end
 		end
-        ::continue::
     end
     return false
 end
@@ -121,44 +119,36 @@ local function repair_box(playername, box)
 	for _, m in ipairs(e[box]) do
 		local uuid = m.id
 		local exists = is_uuid_existing(uuid)
-		if not exists then
-			goto continue
-		elseif are_message_sames(exists, m) then
-			-- same message, continue
-			goto continue
-		else
+		if exists and not are_message_sames(exists, m) then
 			local new_uuid = mail.new_uuid() -- generates a new uuid to replace doublons
 			for _, k in ipairs(mail.storage:get_keys()) do
-				if string.sub(k,1,5) ~= "mail/" then
-					goto continue_r
-				end
-				local p = string.sub(k, 6)
-				local er = mail.get_storage_entry(p)
-				for _, r in ipairs(er.inbox) do
-					if r.id == uuid and not are_message_sames(m, r) then
-						r.id = new_uuid
+				if string.sub(k,1,5) == "mail/" then
+					local p = string.sub(k, 6)
+					local er = mail.get_storage_entry(p)
+					for _, r in ipairs(er.inbox) do
+						if r.id == uuid and not are_message_sames(m, r) then
+							r.id = new_uuid
+						end
 					end
-				end
-				for _, r in ipairs(er.outbox) do
-					if r.id == uuid and not are_message_sames(m, r) then
-						r.id = new_uuid
+					for _, r in ipairs(er.outbox) do
+						if r.id == uuid and not are_message_sames(m, r) then
+							r.id = new_uuid
+						end
 					end
-				end
-				for _, r in ipairs(er.drafts) do
-					if r.id == uuid and not are_message_sames(m, r) then
-						r.id = new_uuid
+					for _, r in ipairs(er.drafts) do
+						if r.id == uuid and not are_message_sames(m, r) then
+							r.id = new_uuid
+						end
 					end
-				end
-				for _, r in ipairs(er.trash) do
-					if r.id == uuid and not are_message_sames(m, r) then
-						r.id = new_uuid
+					for _, r in ipairs(er.trash) do
+						if r.id == uuid and not are_message_sames(m, r) then
+							r.id = new_uuid
+						end
 					end
+					mail.set_storage_entry(p, er)
 				end
-				mail.set_storage_entry(p, er)
-				::continue_r::
 			end
 		end
-		::continue::
 	end
 end
 
@@ -166,15 +156,13 @@ end
 local function repair_storage()
 	-- iterate through players
 	for _, k in ipairs(mail.storage:get_keys()) do
-		if string.sub(k,1,5) ~= "mail/" then
-			goto continue
+		if string.sub(k,1,5) == "mail/" then
+			local p = string.sub(k, 6)
+			repair_box(p, "inbox")
+			repair_box(p, "outbox")
+			repair_box(p, "drafts")
+			repair_box(p, "trash")
 		end
-        local p = string.sub(k, 6)
-		repair_box(p, "inbox")
-		repair_box(p, "outbox")
-		repair_box(p, "drafts")
-		repair_box(p, "trash")
-        ::continue::
 	end
 end
 

--- a/migrate.lua
+++ b/migrate.lua
@@ -80,34 +80,70 @@ local function migrate_v2_to_v3()
 	end)
 end
 
+
+
+local function search_box(playername, box, uuid)
+	local e = mail.get_storage_entry(playername)
+	for _, m in ipairs(e[box]) do
+		if m.id == uuid then
+		return { time = m.time, from = m.from, to = m.to, cc = m.cc, bcc = m.bcc, subject = m.subject, body = m.body } end
+	end
+	return false
+end
+
+local function is_uuid_existing(uuid)
+    for _, k in ipairs(mail.storage:get_keys()) do
+        if string.sub(k,1,5) == "mail/" then
+			local p = string.sub(k, 6)
+			local result
+			local boxes = {"inbox", "outbox", "drafts", "trash"}
+			for _, b in ipairs(boxes) do
+				result = search_box(p, b, uuid)
+				if result then return result end
+			end
+		end
+    end
+    return false
+end
+
+local function are_message_sames(a, b)
+	return a.time == b.time
+	   and a.from == b.from
+	   and a.to == b.to
+	   and a.cc == b.cc
+	   and a.bcc == b.bcc
+	   and a.subject == b.subject
+	   and a.body == b.body
+end
+
 local function repair_box(playername, box)
 	local e = mail.get_storage_entry(playername)
 	for _, m in ipairs(e[box]) do
 		local uuid = m.id
-		local exists = mail.is_uuid_existing(uuid)
-		if exists and not mail.are_message_sames(exists, m) then
+		local exists = is_uuid_existing(uuid)
+		if exists and not are_message_sames(exists, m) then
 			local new_uuid = mail.new_uuid() -- generates a new uuid to replace doublons
 			for _, k in ipairs(mail.storage:get_keys()) do
 				if string.sub(k,1,5) == "mail/" then
 					local p = string.sub(k, 6)
 					local er = mail.get_storage_entry(p)
 					for _, r in ipairs(er.inbox) do
-						if r.id == uuid and not mail.are_message_sames(m, r) then
+						if r.id == uuid and not are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.outbox) do
-						if r.id == uuid and not mail.are_message_sames(m, r) then
+						if r.id == uuid and not are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.drafts) do
-						if r.id == uuid and not mail.are_message_sames(m, r) then
+						if r.id == uuid and not are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.trash) do
-						if r.id == uuid and not mail.are_message_sames(m, r) then
+						if r.id == uuid and not are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end

--- a/migrate.lua
+++ b/migrate.lua
@@ -1,5 +1,5 @@
-
 local STORAGE_VERSION_KEY = "@@version"
+local CURRENT_VERSION = 3.1
 
 local function migrate_v1_to_v3()
 	local file = io.open(minetest.get_worldpath().."/mail.db", "r")
@@ -134,11 +134,11 @@ end
 
 function mail.migrate()
 	-- check for v2 storage first, v1-migration might have set the v3-flag already
-	local version = mail.storage:get_int(STORAGE_VERSION_KEY)
-	if version < 3 then
+	local version = mail.storage:get_float(STORAGE_VERSION_KEY)
+	if version < math.floor(CURRENT_VERSION) then
 		-- v2 to v3
 		migrate_v2_to_v3()
-		mail.storage:set_int(STORAGE_VERSION_KEY, 3)
+		mail.storage:set_float(STORAGE_VERSION_KEY, CURRENT_VERSION)
 	end
 
 	-- check for v1 storage
@@ -146,9 +146,12 @@ function mail.migrate()
 	if v1_file then
 		-- v1 to v3
 		migrate_v1_to_v3()
-		mail.storage:set_int(STORAGE_VERSION_KEY, 3)
+		mail.storage:set_float(STORAGE_VERSION_KEY, CURRENT_VERSION)
 	end
 
 	-- repair storage for uuid doublons
-	repair_storage()
+	if version < CURRENT_VERSION  then
+		repair_storage()
+		mail.storage:set_float(STORAGE_VERSION_KEY, CURRENT_VERSION)
+	end
 end

--- a/migrate.lua
+++ b/migrate.lua
@@ -116,7 +116,7 @@ local function are_message_sames(a, b)
 	   and a.body == b.body
 end
 
-local function repair_box(playername, box)
+local function fix_duplicate_uuids(playername, box)
 	local e = mail.get_storage_entry(playername)
 	for _, m in ipairs(e[box]) do
 		local uuid = m.id
@@ -160,10 +160,10 @@ local function repair_storage()
 	for _, k in ipairs(mail.storage:get_keys()) do
 		if string.sub(k,1,5) == "mail/" then
 			local p = string.sub(k, 6)
-			repair_box(p, "inbox")
-			repair_box(p, "outbox")
-			repair_box(p, "drafts")
-			repair_box(p, "trash")
+			fix_duplicate_uuids(p, "inbox")
+			fix_duplicate_uuids(p, "outbox")
+			fix_duplicate_uuids(p, "drafts")
+			fix_duplicate_uuids(p, "trash")
 		end
 	end
 end

--- a/migrate.lua
+++ b/migrate.lua
@@ -80,68 +80,34 @@ local function migrate_v2_to_v3()
 	end)
 end
 
-local function search_box(playername, box, uuid)
-	local e = mail.get_storage_entry(playername)
-	for _, m in ipairs(e[box]) do
-		if m.id == uuid then
-		return { time = m.time, from = m.from, to = m.to, cc = m.cc, bcc = m.bcc, subject = m.subject, body = m.body } end
-	end
-	return false
-end
-
-local function is_uuid_existing(uuid)
-    for _, k in ipairs(mail.storage:get_keys()) do
-        if string.sub(k,1,5) == "mail/" then
-			local p = string.sub(k, 6)
-			local result
-			local boxes = {"inbox", "outbox", "drafts", "trash"}
-			for _, b in ipairs(boxes) do
-				result = search_box(p, b, uuid)
-				if result then return result end
-			end
-		end
-    end
-    return false
-end
-
-local function are_message_sames(a, b)
-	return a.time == b.time
-	   and a.from == b.from
-	   and a.to == b.to
-	   and a.cc == b.cc
-	   and a.bcc == b.bcc
-	   and a.subject == b.subject
-	   and a.body == b.body
-end
-
 local function repair_box(playername, box)
 	local e = mail.get_storage_entry(playername)
 	for _, m in ipairs(e[box]) do
 		local uuid = m.id
-		local exists = is_uuid_existing(uuid)
-		if exists and not are_message_sames(exists, m) then
+		local exists = mail.is_uuid_existing(uuid)
+		if exists and not mail.are_message_sames(exists, m) then
 			local new_uuid = mail.new_uuid() -- generates a new uuid to replace doublons
 			for _, k in ipairs(mail.storage:get_keys()) do
 				if string.sub(k,1,5) == "mail/" then
 					local p = string.sub(k, 6)
 					local er = mail.get_storage_entry(p)
 					for _, r in ipairs(er.inbox) do
-						if r.id == uuid and not are_message_sames(m, r) then
+						if r.id == uuid and not mail.are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.outbox) do
-						if r.id == uuid and not are_message_sames(m, r) then
+						if r.id == uuid and not mail.are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.drafts) do
-						if r.id == uuid and not are_message_sames(m, r) then
+						if r.id == uuid and not mail.are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end
 					for _, r in ipairs(er.trash) do
-						if r.id == uuid and not are_message_sames(m, r) then
+						if r.id == uuid and not mail.are_message_sames(m, r) then
 							r.id = new_uuid
 						end
 					end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -1,7 +1,7 @@
 -- source: https://gist.github.com/jrus/3197011
 local random = math.random
 
-local function search_box(playername, box, uuid)
+function mail.search_box(playername, box, uuid)
 	local e = mail.get_storage_entry(playername)
 	for _, m in ipairs(e[box]) do
 		if m.id == uuid then
@@ -10,19 +10,29 @@ local function search_box(playername, box, uuid)
 	return false
 end
 
-local function is_uuid_existing(uuid)
+function mail.is_uuid_existing(uuid)
     for _, k in ipairs(mail.storage:get_keys()) do
         if string.sub(k,1,5) == "mail/" then
 			local p = string.sub(k, 6)
 			local result
 			local boxes = {"inbox", "outbox", "drafts", "trash"}
 			for _, b in ipairs(boxes) do
-				result = search_box(p, b, uuid)
+				result = mail.search_box(p, b, uuid)
 				if result then return result end
 			end
 		end
     end
     return false
+end
+
+function mail.are_message_sames(a, b)
+	return a.time == b.time
+	   and a.from == b.from
+	   and a.to == b.to
+	   and a.cc == b.cc
+	   and a.bcc == b.bcc
+	   and a.subject == b.subject
+	   and a.body == b.body
 end
 
 function mail.new_uuid()
@@ -34,6 +44,6 @@ function mail.new_uuid()
                 local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
                 return string.format('%x', v)
             end)
-    until not is_uuid_existing(candidate_uuid)
+    until not mail.is_uuid_existing(candidate_uuid)
     return candidate_uuid
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -1,49 +1,11 @@
 -- source: https://gist.github.com/jrus/3197011
 local random = math.random
 
-function mail.search_box(playername, box, uuid)
-	local e = mail.get_storage_entry(playername)
-	for _, m in ipairs(e[box]) do
-		if m.id == uuid then
-		return { time = m.time, from = m.from, to = m.to, cc = m.cc, bcc = m.bcc, subject = m.subject, body = m.body } end
-	end
-	return false
-end
-
-function mail.is_uuid_existing(uuid)
-    for _, k in ipairs(mail.storage:get_keys()) do
-        if string.sub(k,1,5) == "mail/" then
-			local p = string.sub(k, 6)
-			local result
-			local boxes = {"inbox", "outbox", "drafts", "trash"}
-			for _, b in ipairs(boxes) do
-				result = mail.search_box(p, b, uuid)
-				if result then return result end
-			end
-		end
-    end
-    return false
-end
-
-function mail.are_message_sames(a, b)
-	return a.time == b.time
-	   and a.from == b.from
-	   and a.to == b.to
-	   and a.cc == b.cc
-	   and a.bcc == b.bcc
-	   and a.subject == b.subject
-	   and a.body == b.body
-end
-
 function mail.new_uuid()
     local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-    local candidate_uuid
-    repeat
-        candidate_uuid = string.gsub(template, '[xy]',
-            function (c)
-                local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
-                return string.format('%x', v)
-            end)
-    until not mail.is_uuid_existing(candidate_uuid)
-    return candidate_uuid
+    return string.gsub(template, '[xy]',
+		function (c)
+			local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
+			return string.format('%x', v)
+		end)
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -1,26 +1,28 @@
 -- source: https://gist.github.com/jrus/3197011
 local random = math.random
 
-local function is_uuid_unexisting(uuid)
+local function search_box(playername, box, uuid)
+	local e = mail.get_storage_entry(playername)
+	for _, m in ipairs(e[box]) do
+		if m.id == uuid then
+		return { time = m.time, from = m.from, to = m.to, cc = m.cc, bcc = m.bcc, subject = m.subject, body = m.body } end
+	end
+	return false
+end
+
+local function is_uuid_existing(uuid)
     for _, k in ipairs(mail.storage:get_keys()) do
         if string.sub(k,1,5) == "mail/" then
-            local p = string.sub(k, 6)
-            local e = mail.get_storage_entry(p)
-            for _, m in ipairs(e.inbox) do
-                if m.id == uuid then return false end
-            end
-            for _, m in ipairs(e.outbox) do
-                if m.id == uuid then return false end
-            end
-            for _, m in ipairs(e.drafts) do
-                if m.id == uuid then return false end
-            end
-            for _, m in ipairs(e.trash) do
-                if m.id == uuid then return false end
-            end
-        end
+			local p = string.sub(k, 6)
+			local result
+			local boxes = {"inbox", "outbox", "drafts", "trash"}
+			for _, b in ipairs(boxes) do
+				result = search_box(p, b, uuid)
+				if result then return result end
+			end
+		end
     end
-    return true
+    return false
 end
 
 function mail.new_uuid()
@@ -32,6 +34,6 @@ function mail.new_uuid()
                 local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
                 return string.format('%x', v)
             end)
-    until is_uuid_unexisting(candidate_uuid)
+    until not is_uuid_existing(candidate_uuid)
     return candidate_uuid
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -1,9 +1,34 @@
 -- source: https://gist.github.com/jrus/3197011
 local random = math.random
+
+local function is_uuid_unexisting(uuid)
+    for p, _ in minetest.get_auth_handler().iterate() do
+        local e = mail.get_storage_entry(p)
+        for _, m in ipairs(e.inbox) do
+            if m.id == uuid then return false end
+        end
+        for _, m in ipairs(e.outbox) do
+            if m.id == uuid then return false end
+        end
+        for _, m in ipairs(e.drafts) do
+            if m.id == uuid then return false end
+        end
+        for _, m in ipairs(e.trash) do
+            if m.id == uuid then return false end
+        end
+    end
+    return true
+end
+
 function mail.new_uuid()
     local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-    return string.gsub(template, '[xy]', function (c)
-        local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
-        return string.format('%x', v)
-    end)
+    local candidate_uuid = ""
+    repeat
+        candidate_uuid = string.gsub(template, '[xy]',
+            function (c)
+                local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
+                return string.format('%x', v)
+            end)
+    until is_uuid_unexisting(candidate_uuid)
+    return candidate_uuid
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -1,11 +1,9 @@
 -- source: https://gist.github.com/jrus/3197011
 local random = math.random
-
 function mail.new_uuid()
     local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-    return string.gsub(template, '[xy]',
-		function (c)
-			local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
-			return string.format('%x', v)
-		end)
+    return string.gsub(template, '[xy]', function (c)
+        local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
+        return string.format('%x', v)
+    end)
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -27,7 +27,7 @@ end
 
 function mail.new_uuid()
     local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-    local candidate_uuid = ""
+    local candidate_uuid
     repeat
         candidate_uuid = string.gsub(template, '[xy]',
             function (c)

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -3,24 +3,22 @@ local random = math.random
 
 local function is_uuid_unexisting(uuid)
     for _, k in ipairs(mail.storage:get_keys()) do
-        if string.sub(k,1,5) ~= "mail/" then
-            goto continue
+        if string.sub(k,1,5) == "mail/" then
+            local p = string.sub(k, 6)
+            local e = mail.get_storage_entry(p)
+            for _, m in ipairs(e.inbox) do
+                if m.id == uuid then return false end
+            end
+            for _, m in ipairs(e.outbox) do
+                if m.id == uuid then return false end
+            end
+            for _, m in ipairs(e.drafts) do
+                if m.id == uuid then return false end
+            end
+            for _, m in ipairs(e.trash) do
+                if m.id == uuid then return false end
+            end
         end
-        local p = string.sub(k, 6)
-        local e = mail.get_storage_entry(p)
-        for _, m in ipairs(e.inbox) do
-            if m.id == uuid then return false end
-        end
-        for _, m in ipairs(e.outbox) do
-            if m.id == uuid then return false end
-        end
-        for _, m in ipairs(e.drafts) do
-            if m.id == uuid then return false end
-        end
-        for _, m in ipairs(e.trash) do
-            if m.id == uuid then return false end
-        end
-        ::continue::
     end
     return true
 end

--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -2,7 +2,11 @@
 local random = math.random
 
 local function is_uuid_unexisting(uuid)
-    for p, _ in minetest.get_auth_handler().iterate() do
+    for _, k in ipairs(mail.storage:get_keys()) do
+        if string.sub(k,1,5) ~= "mail/" then
+            goto continue
+        end
+        local p = string.sub(k, 6)
         local e = mail.get_storage_entry(p)
         for _, m in ipairs(e.inbox) do
             if m.id == uuid then return false end
@@ -16,6 +20,7 @@ local function is_uuid_unexisting(uuid)
         for _, m in ipairs(e.trash) do
             if m.id == uuid then return false end
         end
+        ::continue::
     end
     return true
 end


### PR DESCRIPTION
This is a proposal for the most important hotfix of this release. What does it do ?
* It first checks, when giving an UUID, if it is not already used in the database ;
* At the startup, in after migrating in `migrate.lua`, it checks for non-duplicates, and if there are, it gives new ID to all messages that are not the same (`mail.are_message_sames()`). Of course, because it iterates through all messages, after fixing message1, it checks message2, so if there is a message3 also concerned by the duplicate, it is fixed in the message2 loop.

I tested it with 10 000 messages, it runs quite good (no performance loss). If you want to test it, you can use the `/mail_spam` command written in #103.

Of course, performance can still be improved, but that's not really a mess here.

I ping @Bastrabun because he was the first who noticed the issue on Your Land.

Fix #122, #126.