### PR TITLE
Add support for tree-hierarchized settings groups

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,7 +5,7 @@ globals = {
 read_globals = {
 	-- Stdlib
 	string = {fields = {"split"}},
-	table = {fields = {"copy", "getn", "indexof"}},
+	table = {fields = {"copy", "getn", "indexof", "insert_all"}},
 	beerchat = {fields = {"has_player_muted_player", "execute_callbacks"}},
 
 	-- Minetest

--- a/util/settings.lua
+++ b/util/settings.lua
@@ -26,11 +26,11 @@ mail.settings = {
         label = S("Show CC/BCC in different color")
     },
     defaultsortfield = {
-        type = "index", default = 3, group = "message_list", index = 3,
+        type = "index", default = 3, group = "box_fields", index = 1,
         label = S("Default sorting field"), dataset = { S("From/To"), S("Subject"), S("Date") }
     },
     defaultsortdirection = {
-        type = "index", default = 1, group = "message_list", index = 4,
+        type = "index", default = 1, group = "box_fields", index = 2,
         label = S("Default sorting direction"), dataset = { S("Ascending"), S("Descending") }
     },
     trash_move_enable = {
@@ -52,10 +52,11 @@ mail.settings = {
 }
 
 mail.settings_groups = {
-    { name = "notifications", label = S("Notifications")},
-    { name = "message_list",  label = S("Message list")},
-    { name = "spam",          label = S("Spam")},
-    { name = "other",         label = S("Other")}
+    { name = "notifications", label = S("Notifications"), index = 1, parent = 0},
+    { name = "message_list",  label = S("Message list"),  index = 2, parent = 0},
+    { name = "box_fields",    label = S("Fields"),        index = 1, parent = "message_list"},
+    { name = "spam",          label = S("Spam"),          index = 3, parent = 0},
+    { name = "other",         label = S("Other"),         index = 4, parent = 0}
 }
 
 for s, d in pairs(mail.settings) do


### PR DESCRIPTION
Hi,

This is not a big change, but it might be used in the future.

There are two commits, I prefer non-squash for this one : 
* Add a support for parent settings, in `ui/settings.lua` it generates it with a recursive function (not so bad because it is not intended to get thousands of categories)
* Move existing `Default sorting field/direction` to new group `Fields`, child of `Message list`

NB : I'm gonna do a new fields-related setting, so of course this was in my "roadmap" (not famous for being linear lol)
NB2 : I plan to move settings and other non-mail related stuff to new general mods.

![screenshot_20240407_165640](https://github.com/mt-mods/mail/assets/75171564/c6a7c098-d632-4cd7-9110-5d8ff8baffef)
