### PR TITLE
Add Timezone offset setting + setting type number

### DIFF
--- a/ui/message.lua
+++ b/ui/message.lua
@@ -58,7 +58,8 @@ function mail.show_message(name, id)
 	local cc = minetest.formspec_escape(message.cc) or ""
 	if string.len(cc) > 50 then cc = string.sub(cc, 1, 47) .. "..." end
 	local date = type(message.time) == "number"
-		and minetest.formspec_escape(os.date(mail.get_setting(name, "date_format"), message.time)) or ""
+		and minetest.formspec_escape(os.date(mail.get_setting(name, "date_format"),
+		message.time+3600*mail.get_setting(name, "timezone_offset"))) or ""
 	local subject = minetest.formspec_escape(message.subject) or ""
 	local body = minetest.formspec_escape(message.body) or ""
 	formspec = string.format(formspec, from, to, cc, date, subject, body)

--- a/ui/settings.lua
+++ b/ui/settings.lua
@@ -109,7 +109,35 @@ function mail.show_settings(name)
                 dataset_str .. [[;]] .. dataset_selected_id .. [[;true]
                 ]]
             end
-
+        elseif data.type == "number" then
+            y = y + 1
+            formspec = formspec .. [[
+            field[]] .. x+0.275 .. "," .. y .. ";3,0.5;" .. setting .. ";" .. data.label .. [[;]] ..
+            tostring(field_default) .. [[]
+            ]]
+            if data.tooltip then
+                formspec = formspec .. "tooltip[" .. setting .. ";" .. data.tooltip .. "]"
+            end
+            if data.dataset then
+                local formatted_dataset = table.copy(data.dataset)
+                if data.format then
+                    for i, d in ipairs(formatted_dataset) do
+                        formatted_dataset[i] = data.format(d)
+                    end
+                end
+                local dataset_str = table.concat(formatted_dataset, ",")
+                local dataset_selected_id = 1
+                for i, d in ipairs(data.dataset) do
+                    if d == field_default then
+                        dataset_selected_id = i
+                        break
+                    end
+                end
+                formspec = formspec .. [[
+                dropdown[]] .. x+3 .. "," .. y-0.45 .. ";3,0.5;" .. "dataset_" .. setting .. ";" ..
+                dataset_str .. [[;]] .. dataset_selected_id .. [[;true]
+                ]]
+            end
         elseif data.type == "index" then
             y = y + 0.2
             local formatted_dataset = table.copy(data.dataset)
@@ -174,8 +202,13 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
             elseif data.type == "string" then
                 if data.dataset and fields["dataset_" .. setting] then
                     mail.selected_idxs[setting][playername] = data.dataset[tonumber(fields["dataset_" .. setting])]
+                    mail.show_settings(playername)
                 end
-                mail.show_settings(playername)
+            elseif data.type == "number" then
+                if data.dataset and fields["dataset_" .. setting] then
+                    mail.selected_idxs[setting][playername] = data.dataset[tonumber(fields["dataset_" .. setting])]
+                    mail.show_settings(playername)
+                end
             elseif data.type == "index" then
                 mail.selected_idxs[setting][playername] = tonumber(fields[setting])
             elseif data.type == "list" then

--- a/util/settings.lua
+++ b/util/settings.lua
@@ -45,6 +45,10 @@ mail.settings = {
         type = "string", default = "%Y-%m-%d %X", group = "other", index = 3, label = S("Date format"),
         dataset = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}, format = os.date
     },
+    timezone_offset = {
+        type = "number", default = 0, group = "other", index = 4,
+        label = S("Timezone offset"), tooltip = S("Offset to add to server time."),
+    },
     mute_list = {
         type = "list", default = {}, group = "spam", index = 1,
         label = S("Mute list")

--- a/util/settings.lua
+++ b/util/settings.lua
@@ -42,11 +42,11 @@ mail.settings = {
         label = S("Automatic marking read"), tooltip = S("Mark a message as read when opened")
     },
     date_format = {
-        type = "string", default = "%Y-%m-%d %X", group = "other", index = 3, label = S("Date format"),
+        type = "string", default = "%Y-%m-%d %X", group = "date_and_time", index = 3, label = S("Date format"),
         dataset = {"%Y-%m-%d %X", "%d/%m/%y %X", "%A %d %B %Y %X"}, format = os.date
     },
     timezone_offset = {
-        type = "number", default = 0, group = "other", index = 4,
+        type = "number", default = 0, group = "date_and_time", index = 4,
         label = S("Timezone offset"), tooltip = S("Offset to add to server time."),
     },
     mute_list = {
@@ -60,7 +60,8 @@ mail.settings_groups = {
     { name = "message_list",  label = S("Message list"),  index = 2, parent = 0},
     { name = "box_fields",    label = S("Fields"),        index = 1, parent = "message_list"},
     { name = "spam",          label = S("Spam"),          index = 3, parent = 0},
-    { name = "other",         label = S("Other"),         index = 4, parent = 0}
+    { name = "other",         label = S("Other"),         index = 4, parent = 0},
+    { name = "date_and_time", label = S("Date and Time"), index = 1, parent = "other"}
 }
 
 for s, d in pairs(mail.settings) do


### PR DESCRIPTION
This PR has 2 commits : 
* Add support for setting type `number`. Almost like `string`.
* Add `timezone_offset` setting, and add it to the message date.

Rebase should be the best option.

Quite simple, the review should be quick :wink:

Resolve #125 

![screenshot_20240414_154706](https://github.com/mt-mods/mail/assets/75171564/9cc3d303-9784-4e4f-9eaf-2796a6835b07)
![screenshot_20240414_154711](https://github.com/mt-mods/mail/assets/75171564/401d98f5-3ce4-4121-81a0-ea2880b8df38)
![screenshot_20240414_154722](https://github.com/mt-mods/mail/assets/75171564/8a230349-6312-4acc-af3d-ef8e19c4a19f)
