### PR TITLE
Optimize performance of the inbox

### DIFF
--- a/ui/inbox.lua
+++ b/ui/inbox.lua
@@ -77,6 +77,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
 
     local unread_color_enable = mail.get_setting(name, "unreadcolorenable")
     local cc_color_enable = mail.get_setting(name, "cccolorenable")
+    local mute_list = mail.get_setting(name, "mute_list")
 
     if #messages > 0 then
         for _, message in ipairs(messages) do
@@ -103,7 +104,7 @@ function mail.show_inbox(name, sortfieldindex, sortdirection, filter)
             if message.spam then
                 table.insert(displayed_color, "warning")
             end
-            if table.indexof(mail.get_setting(name, "mute_list"), message.from) >= 1 then
+            if table.indexof(mute_list, message.from) >= 1 then
                 table.insert(displayed_color, "muted")
             end
             formspec[#formspec + 1] = "," .. mail.get_color(displayed_color)


### PR DESCRIPTION
Moves the `mail.get_setting(name, "mute_list")` call out of the message loop. Previously, this is repeated, causing disastrous lag when using mail with beerchat.

This PR is ready for review.

[Profiler report before the change](https://github.com/user-attachments/assets/b90ad64d-2031-430c-9c85-5c3a4c75276a)

[Profiler report after the change](https://github.com/user-attachments/assets/abf402b2-3aa1-40dd-a5a3-880dd934c139)
