### PR TITLE
Add support for a get_keys() equivalent for lower than 5.7 Minetest versions

### DIFF
--- a/migrate.lua
+++ b/migrate.lua
@@ -175,7 +175,7 @@ end
 local function repair_storage()
 	-- iterate through players
 	-- get_keys() was introduced in 5.7
-	if mail.storage:get_keys() then
+	if mail.storage.get_keys then
 		for _, k in ipairs(mail.storage:get_keys()) do
 			if string.sub(k,1,5) == "mail/" then
 				local p = string.sub(k, 6)

--- a/migrate.lua
+++ b/migrate.lua
@@ -91,16 +91,28 @@ local function search_box(playername, box, uuid)
 	return false
 end
 
+local function search_boxes(playername, boxes, uuid)
+	local result
+	for _, b in ipairs(boxes) do
+		result = search_box(playername, b, uuid)
+		if result then return result end
+	end
+end
+
 local function is_uuid_existing(uuid)
-    for _, k in ipairs(mail.storage:get_keys()) do
-        if string.sub(k,1,5) == "mail/" then
-			local p = string.sub(k, 6)
-			local result
-			local boxes = {"inbox", "outbox", "drafts", "trash"}
-			for _, b in ipairs(boxes) do
-				result = search_box(p, b, uuid)
+	local boxes = {"inbox", "outbox", "drafts", "trash"}
+	if mail.storage.get_keys then
+		for _, k in ipairs(mail.storage:get_keys()) do
+			if string.sub(k,1,5) == "mail/" then
+				local p = string.sub(k, 6)
+				local result = search_boxes(p, boxes, uuid)
 				if result then return result end
 			end
+		end
+	else
+		for p, _ in minetest.get_auth_handler().iterate() do
+			local result = search_boxes(p, boxes, uuid)
+			if result then return result end
 		end
     end
     return false

--- a/migrate.lua
+++ b/migrate.lua
@@ -148,7 +148,7 @@ local function fix_box_duplicate_uuids(playername, box)
 		local exists = is_uuid_existing(uuid)
 		if exists and not are_message_sames(exists, m) then
 			local new_uuid = mail.new_uuid() -- generates a new uuid to replace doublons
-			if mail.storage:get_keys() then
+			if mail.storage.get_keys then
 				for _, k in ipairs(mail.storage:get_keys()) do
 					if string.sub(k,1,5) == "mail/" then
 						local p = string.sub(k, 6)


### PR DESCRIPTION
Fix #152 

@MoNTE48 can you confirm me that it works ?

Notes :
- It checks if `get_keys()` exists
- Then, if not, it iterates through existing players (but consume more)
- I've also reorganized into more functions to not have too much duplicates